### PR TITLE
New Directories for FreeRTOS Port - Stubbed OSAL

### DIFF
--- a/osal/src/bsp/arm-freertos/CMakeLists.txt
+++ b/osal/src/bsp/arm-freertos/CMakeLists.txt
@@ -1,0 +1,30 @@
+######################################################################
+#
+# CMAKE build recipe for FREERTOS Board Support Package (BSP)
+#
+######################################################################
+
+# This basic implementation library should be generic enough to use
+# on any Linux-based processor board, as well as a standard development PC.
+add_library(osal_arm-freertos_impl OBJECT
+	src/bsp_start.c
+	src/bsp_console.c
+)
+
+# OSAL needs conformance to at least POSIX.1c (aka POSIX 1995) - this includes all the
+# real-time support and threading extensions.
+#
+# When compiling against glibc, using "_XOPEN_SOURCE=600" enables the X/Open 6 standard.
+# XPG6 includes all necessary XPG5, POSIX.1c features as well as SUSv2/UNIX98 extensions.
+# This OSAL implementation uses clock_nanosleep(), mq_timedreceive(), and
+# mq_timedsend() which are enhancements added in the XPG6 standard.
+#
+# See http://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html
+# for a more detailed description of the feature test macros and available values
+target_compile_definitions(osal_arm-freertos_impl PUBLIC
+    _XOPEN_SOURCE=600
+)
+
+
+# Confirming this reduces risk of accidental misconfiguration
+set(OSAL_EXPECTED_OSTYPE    "freertos" PARENT_SCOPE)

--- a/osal/src/bsp/arm-freertos/build_options.cmake
+++ b/osal/src/bsp/arm-freertos/build_options.cmake
@@ -1,0 +1,23 @@
+##########################################################################
+#
+# Build options for "arm-freertos" BSP
+#
+##########################################################################
+
+
+
+# Linux system libraries required for the final link of applications using OSAL
+target_link_libraries(osal_bsp
+    pthread dl rt
+)
+
+# C flags that should be used when (re-) compiling code for unit testing.
+# Note: --coverage is just a shortcut for "-ftest-coverage" and "-fprofile-arcs"
+# This also does not work well when cross compiling since paths to the _compile_ dir
+# are baked into the executables, so they will not be there when copied to the target
+# Note - although GCC understands the same flags for compile and link here, this may
+# not be true on all platforms so the compile and link flags are specified separately.
+if (NOT CMAKE_CROSSCOMPILING)
+  set(UT_COVERAGE_COMPILE_FLAGS -pg --coverage)
+  set(UT_COVERAGE_LINK_FLAGS    -pg --coverage)
+endif()

--- a/osal/src/bsp/arm-freertos/src/bsp_console.c
+++ b/osal/src/bsp/arm-freertos/src/bsp_console.c
@@ -1,0 +1,48 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * File:  bsp_console.c
+ *
+ * Purpose:
+ *   OSAL BSP debug console abstraction
+ */
+
+#include "bsp-impl.h"
+
+/****************************************************************************************
+                    BSP CONSOLE IMPLEMENTATION FUNCTIONS
+ ****************************************************************************************/
+
+/*----------------------------------------------------------------
+   OS_BSP_ConsoleOutput_Impl
+   See full description in header
+ ------------------------------------------------------------------*/
+void OS_BSP_ConsoleOutput_Impl(const char *Str, uint32 DataLen)
+{
+}
+
+/*----------------------------------------------------------------
+   OS_BSP_ConsoleSetMode_Impl() definition
+   See full description in header
+ ------------------------------------------------------------------*/
+void OS_BSP_ConsoleSetMode_Impl(uint32 ModeBits)
+{
+}

--- a/osal/src/bsp/arm-freertos/src/bsp_start.c
+++ b/osal/src/bsp/arm-freertos/src/bsp_start.c
@@ -1,0 +1,72 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * File:  bsp_start.c
+ *
+ * Purpose:
+ *   OSAL BSP main entry point.
+ */
+
+#include "generic_freertos_bsp_internal.h"
+
+OS_BSP_GenericFreeRTOSGlobalData_t OS_BSP_GenericFreeRTOSGlobal;
+
+void OS_BSP_Initialize(void)
+{
+}
+
+/* ---------------------------------------------------------
+    OS_BSP_GetReturnStatus()
+
+     Helper function to convert an OSAL status code into
+     a code suitable for returning to the OS.
+   --------------------------------------------------------- */
+int OS_BSP_GetReturnStatus(void)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+}
+
+/* ---------------------------------------------------------
+    OS_BSP_Shutdown_Impl()
+
+     Helper function to abort the running task
+   --------------------------------------------------------- */
+void OS_BSP_Shutdown_Impl(void)
+{
+}
+
+
+/******************************************************************************
+**  Function:  main()
+**
+**  Purpose:
+**    BSP Application entry point.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+
+int main(int argc, char *argv[])
+{
+}

--- a/osal/src/bsp/arm-freertos/src/generic_freertos_bsp_internal.h
+++ b/osal/src/bsp/arm-freertos/src/generic_freertos_bsp_internal.h
@@ -1,0 +1,46 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ * File:  generic_freertos_bsp_internal.h
+ *
+ * Purpose:
+ *   Header file for internal data to the FREERTOS BSP
+ */
+
+#ifndef GENERIC_FREERTOS_BSP_INTERNAL_H_
+#define GENERIC_FREERTOS_BSP_INTERNAL_H_
+
+#include "bsp-impl.h"
+
+/*
+** BSP types
+*/
+typedef struct
+{
+    bool    EnableTermControl;    /**< Will be set "true" when invoked from a TTY device, false otherwise */
+} OS_BSP_GenericFreeRTOSGlobalData_t;
+
+/*
+ * Global Data object
+ */
+extern OS_BSP_GenericFreeRTOSGlobalData_t OS_BSP_GenericFreeRTOSGlobal;
+
+#endif /* GENERIC_FREERTOS_BSP_INTERNAL_H_ */

--- a/osal/src/os/freertos/CMakeLists.txt
+++ b/osal/src/os/freertos/CMakeLists.txt
@@ -1,0 +1,91 @@
+######################################################################
+#
+# CMAKE build recipe for FREERTOS OSAL implementation
+#
+######################################################################
+
+# This CMake script generates targets specific to the FREERTOS implementation
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/inc)
+
+# The basic set of files which are always built
+set(FREERTOS_BASE_SRCLIST
+    src/os-impl-binsem.c
+    src/os-impl-common.c
+    src/os-impl-console.c
+    src/os-impl-countsem.c
+    src/os-impl-dirs.c
+    src/os-impl-errors.c
+    src/os-impl-files.c
+    src/os-impl-filesys.c
+    src/os-impl-heap.c
+    src/os-impl-idmap.c
+    src/os-impl-mutex.c
+    src/os-impl-queues.c
+    src/os-impl-tasks.c
+    src/os-impl-timebase.c
+)
+
+# The FPU and interrupt modules are deprecated.
+# If the "OMIT_DEPRECATED" switch is set, then these are not built.
+if (NOT OMIT_DEPRECATED)
+    list(APPEND FREERTOS_BASE_SRCLIST
+        src/os-impl-fpu.c
+        src/os-impl-interrupts.c
+    )
+endif (NOT OMIT_DEPRECATED)
+
+
+
+# Use portable blocks for basic I/O
+set(FREERTOS_IMPL_SRCLIST
+    ../portable/os-impl-posix-gettime.c
+    ../portable/os-impl-console-bsp.c
+    ../portable/os-impl-bsd-select.c
+    ../portable/os-impl-posix-io.c
+    ../portable/os-impl-posix-files.c
+    ../portable/os-impl-posix-dirs.c
+)
+
+if (OSAL_CONFIG_INCLUDE_SHELL)
+    list(APPEND FREERTOS_IMPL_SRCLIST
+       src/os-impl-shell.c
+    )
+else ()
+    list(APPEND FREERTOS_IMPL_SRCLIST
+       ../portable/os-impl-no-shell.c
+    )
+endif ()
+
+# If some form of module loading is configured,
+# then build the module loader
+if (OSAL_CONFIG_INCLUDE_DYNAMIC_LOADER)
+    list(APPEND FREERTOS_IMPL_SRCLIST
+        src/os-impl-loader.c
+        ../portable/os-impl-posix-dl-loader.c
+        ../portable/os-impl-posix-dl-symtab.c
+    )
+else ()
+    list(APPEND FREERTOS_IMPL_SRCLIST
+        src/os-impl-no-module.c
+        ../portable/os-impl-no-loader.c
+        ../portable/os-impl-no-symtab.c
+    )
+endif ()
+
+if (OSAL_CONFIG_INCLUDE_NETWORK)
+    list(APPEND FREERTOS_IMPL_SRCLIST
+        ../portable/os-impl-bsd-sockets.c   # Use BSD socket layer implementation
+        ../portable/os-impl-posix-network.c # Use POSIX-defined hostname/id implementation
+    )
+else()
+    list(APPEND FREERTOS_IMPL_SRCLIST
+        ../portable/os-impl-no-network.c    # non-implemented versions of all network APIs
+        ../portable/os-impl-no-sockets.c    # non-implemented versions of all socket APIs
+    )
+endif ()
+
+# Defines an OBJECT target named "osal_arm-freertos_impl" with selected source files
+add_library(osal_freertos_impl OBJECT
+    ${FREERTOS_BASE_SRCLIST}
+    ${FREERTOS_IMPL_SRCLIST}
+)

--- a/osal/src/os/freertos/build_options.cmake
+++ b/osal/src/os/freertos/build_options.cmake
@@ -1,0 +1,9 @@
+##########################################################################
+#
+# Build options for "FreeRTOS" implementation layer
+#
+##########################################################################
+
+# this file is a placeholder for FREERTOS-specific compile tuning
+# currently no extra flags/definitions needed
+ 

--- a/osal/src/os/freertos/inc/os-freertos.h
+++ b/osal/src/os/freertos/inc/os-freertos.h
@@ -28,8 +28,8 @@
  *          may contain POSIX-specific definitions.
  */
 
-#ifndef INCLUDE_OS_POSIX_H_
-#define INCLUDE_OS_POSIX_H_
+#ifndef INCLUDE_OS_FREERTOS_H_
+#define INCLUDE_OS_FREERTOS_H_
 
 
 /****************************************************************************************

--- a/osal/src/os/freertos/inc/os-freertos.h
+++ b/osal/src/os/freertos/inc/os-freertos.h
@@ -1,0 +1,83 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-posix.h
+ * \ingroup  posix
+ * \author   joseph.p.hickey@nasa.gov
+ *
+ * Purpose: This file contains definitions that are shared across the POSIX
+ *          OSAL implementation.  This file is private to the POSIX port and it
+ *          may contain POSIX-specific definitions.
+ */
+
+#ifndef INCLUDE_OS_POSIX_H_
+#define INCLUDE_OS_POSIX_H_
+
+
+/****************************************************************************************
+                                    COMMON INCLUDE FILES
+ ***************************************************************************************/
+
+/*
+ * Use the global definitions from the shared layer
+ */
+#include "os-shared-globaldefs.h"
+
+/****************************************************************************************
+                                     DEFINES
+ ***************************************************************************************/
+
+/****************************************************************************************
+                                    TYPEDEFS
+ ***************************************************************************************/
+
+typedef struct
+{
+   int reserve;
+} FREERTOS_GlobalVars_t;
+
+
+/****************************************************************************************
+                                   GLOBAL DATA
+ ***************************************************************************************/
+
+extern FREERTOS_GlobalVars_t FREERTOS_GlobalVars;
+
+
+/****************************************************************************************
+                       POSIX IMPLEMENTATION FUNCTION PROTOTYPES
+ ***************************************************************************************/
+
+int32 OS_FreeRTOS_TaskAPI_Impl_Init(void);
+int32 OS_FreeRTOS_QueueAPI_Impl_Init(void);
+int32 OS_FreeRTOS_BinSemAPI_Impl_Init(void);
+int32 OS_FreeRTOS_CountSemAPI_Impl_Init(void);
+int32 OS_FreeRTOS_MutexAPI_Impl_Init(void);
+int32 OS_FreeRTOS_ModuleAPI_Impl_Init(void);
+int32 OS_FreeRTOS_TimeBaseAPI_Impl_Init(void);
+int32 OS_FreeRTOS_StreamAPI_Impl_Init(void);
+int32 OS_FreeRTOS_DirAPI_Impl_Init(void);
+int32 OS_FreeRTOS_FileSysAPI_Impl_Init(void);
+
+int32 OS_FreeRTOS_TableMutex_Init(uint32 idtype);
+
+#endif  /* INCLUDE_OS_POSIX_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-binsem.h
+++ b/osal/src/os/freertos/inc/os-impl-binsem.h
@@ -1,0 +1,44 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-binsem.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_BINSEM_H_
+#define INCLUDE_OS_IMPL_BINSEM_H_
+
+#include <osconfig.h>
+
+/* Binary Semaphores */
+typedef struct
+{
+    int    reserve;
+} OS_impl_binsem_internal_record_t;
+
+/* Tables where the OS object information is stored */
+extern OS_impl_binsem_internal_record_t    OS_impl_bin_sem_table       [OS_MAX_BIN_SEMAPHORES];
+
+
+
+#endif  /* INCLUDE_OS_IMPL_BINSEM_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-console.h
+++ b/osal/src/os/freertos/inc/os-impl-console.h
@@ -1,0 +1,43 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-console.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_CONSOLE_H_
+#define INCLUDE_OS_IMPL_CONSOLE_H_
+
+#include <osconfig.h>
+
+/* Console device */
+typedef struct
+{
+    int reserve;
+}OS_impl_console_internal_record_t;
+
+
+extern OS_impl_console_internal_record_t   OS_impl_console_table       [OS_MAX_CONSOLES];
+
+
+#endif  /* INCLUDE_OS_IMPL_CONSOLE_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-countsem.h
+++ b/osal/src/os/freertos/inc/os-impl-countsem.h
@@ -1,0 +1,42 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-countsem.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_COUNTSEM_H_
+#define INCLUDE_OS_IMPL_COUNTSEM_H_
+
+#include <osconfig.h>
+
+typedef struct
+{
+    int           reserve;
+} OS_impl_countsem_internal_record_t;
+
+/* Tables where the OS object information is stored */
+extern OS_impl_countsem_internal_record_t  OS_impl_count_sem_table     [OS_MAX_COUNT_SEMAPHORES];
+
+
+#endif  /* INCLUDE_OS_IMPL_COUNTSEM_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-dirs.h
+++ b/osal/src/os/freertos/inc/os-impl-dirs.h
@@ -1,0 +1,49 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-dirs.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_DIRS_H_
+#define INCLUDE_OS_IMPL_DIRS_H_
+
+#include <osconfig.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <sys/stat.h>
+
+typedef struct
+{
+    DIR *dp;
+} OS_impl_dir_internal_record_t;
+
+
+/*
+ * The directory handle table.
+ */
+extern OS_impl_dir_internal_record_t OS_impl_dir_table[OS_MAX_NUM_OPEN_DIRS];
+
+
+
+#endif  /* INCLUDE_OS_IMPL_DIRS_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-files.h
+++ b/osal/src/os/freertos/inc/os-impl-files.h
@@ -1,0 +1,52 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-files.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_FILES_H_
+#define INCLUDE_OS_IMPL_FILES_H_
+
+#include "os-impl-io.h"
+
+#include <fcntl.h>
+#include <sys/stat.h>
+
+
+/*
+ * These two constants (EUID and EGID) are local cache of the
+ * euid and egid of the user running the OSAL application.  They
+ * assist the "stat" implementation in determination of permissions.
+ *
+ * For an OS that does not have multiple users, these could be
+ * defined as 0.  Otherwise they should be populated via the system
+ * geteuid/getegid calls.
+ */
+extern uid_t OS_IMPL_SELF_EUID;
+extern gid_t OS_IMPL_SELF_EGID;
+
+
+extern const int OS_IMPL_REGULAR_FILE_FLAGS;
+
+#endif  /* INCLUDE_OS_IMPL_FILES_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-gettime.h
+++ b/osal/src/os/freertos/inc/os-impl-gettime.h
@@ -1,0 +1,37 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-gettime.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_GETTIME_H_
+#define INCLUDE_OS_IMPL_GETTIME_H_
+
+#include <time.h>
+
+
+#define OSAL_GETTIME_SOURCE_CLOCK       CLOCK_MONOTONIC
+
+
+#endif  /* INCLUDE_OS_IMPL_GETTIME_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-io.h
+++ b/osal/src/os/freertos/inc/os-impl-io.h
@@ -1,0 +1,50 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-io.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_IO_H_
+#define INCLUDE_OS_IMPL_IO_H_
+
+#include <osconfig.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+typedef struct
+{
+    int fd;
+    bool selectable;
+} OS_FreeRTOS_filehandle_entry_t;
+
+/*
+ * The global file handle table.
+ *
+ * This is shared by all OSAL entities that perform low-level I/O.
+ */
+extern OS_FreeRTOS_filehandle_entry_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
+
+
+
+#endif  /* INCLUDE_OS_IMPL_IO_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-loader.h
+++ b/osal/src/os/freertos/inc/os-impl-loader.h
@@ -1,0 +1,46 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-loader.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_LOADER_H_
+#define INCLUDE_OS_IMPL_LOADER_H_
+
+#include <osconfig.h>
+#include <dlfcn.h>
+
+/*
+ * A local lookup table for FreeRTOS-specific information.
+ * This is not directly visible to the outside world.
+ */
+typedef struct
+{
+    /* cppcheck-suppress unusedStructMember */
+    void *dl_handle;
+} OS_impl_module_internal_record_t;
+
+extern OS_impl_module_internal_record_t OS_impl_module_table[OS_MAX_MODULES];
+
+#endif  /* INCLUDE_OS_IMPL_LOADER_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-mutex.h
+++ b/osal/src/os/freertos/inc/os-impl-mutex.h
@@ -1,0 +1,43 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-mutex.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_MUTEX_H_
+#define INCLUDE_OS_IMPL_MUTEX_H_
+
+#include <osconfig.h>
+
+/* Mutexes */
+typedef struct
+{
+    int reserve;
+} OS_impl_mutex_internal_record_t;
+
+/* Tables where the OS object information is stored */
+extern OS_impl_mutex_internal_record_t   OS_impl_mutex_table       [OS_MAX_MUTEXES];
+
+
+#endif  /* INCLUDE_OS_IMPL_MUTEX_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-network.h
+++ b/osal/src/os/freertos/inc/os-impl-network.h
@@ -1,0 +1,38 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-network.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/*
+ * TODO: remove this once we move these files into FreeRTOS directory.
+*  Currently the portable code calls this in os-impl-posix-network.c
+ */
+
+#ifndef INCLUDE_OS_IMPL_NETWORK_H_
+#define INCLUDE_OS_IMPL_NETWORK_H_
+
+#include <unistd.h>
+
+#endif  /* INCLUDE_OS_IMPL_NETWORK_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-queues.h
+++ b/osal/src/os/freertos/inc/os-impl-queues.h
@@ -1,0 +1,43 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-queues.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_QUEUES_H_
+#define INCLUDE_OS_IMPL_QUEUES_H_
+
+#include <osconfig.h>
+
+/* queues */
+typedef struct
+{
+    int reserve;
+} OS_impl_queue_internal_record_t;
+
+/* Tables where the OS object information is stored */
+extern OS_impl_queue_internal_record_t     OS_impl_queue_table         [OS_MAX_QUEUES];
+
+
+#endif  /* INCLUDE_OS_IMPL_QUEUES_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-select.h
+++ b/osal/src/os/freertos/inc/os-impl-select.h
@@ -1,0 +1,36 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-select.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_SELECT_H_
+#define INCLUDE_OS_IMPL_SELECT_H_
+
+#include "os-impl-io.h"
+
+#include <sys/time.h>
+
+
+#endif  /* INCLUDE_OS_IMPL_SELECT_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-sockets.h
+++ b/osal/src/os/freertos/inc/os-impl-sockets.h
@@ -1,0 +1,46 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-sockets.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_SOCKETS_H_
+#define INCLUDE_OS_IMPL_SOCKETS_H_
+
+#include "os-impl-io.h"
+
+#include <fcntl.h>
+#include <arpa/inet.h>
+
+
+
+/*
+ * A full POSIX-compliant I/O layer should support using
+ * nonblocking I/O calls in combination with select().
+ */
+#define OS_IMPL_SOCKET_FLAGS        O_NONBLOCK
+
+
+
+#endif  /* INCLUDE_OS_IMPL_SOCKETS_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-tasks.h
+++ b/osal/src/os/freertos/inc/os-impl-tasks.h
@@ -1,0 +1,44 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-tasks.h
+ * \ingroup  posix
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_TASKS_H_
+#define INCLUDE_OS_IMPL_TASKS_H_
+
+#include <osconfig.h>
+
+/*tasks */
+typedef struct
+{
+    int reserve;
+} OS_impl_task_internal_record_t;
+
+
+/* Tables where the OS object information is stored */
+extern OS_impl_task_internal_record_t      OS_impl_task_table          [OS_MAX_TASKS];
+
+
+#endif  /* INCLUDE_OS_IMPL_TASKS_H_ */
+

--- a/osal/src/os/freertos/inc/os-impl-timebase.h
+++ b/osal/src/os/freertos/inc/os-impl-timebase.h
@@ -1,0 +1,47 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-timebase.h
+ * \ingroup  FreeRTOS
+ *
+ */
+
+#ifndef INCLUDE_OS_IMPL_TIMEBASE_H_
+#define INCLUDE_OS_IMPL_TIMEBASE_H_
+
+#include <osconfig.h>
+
+
+typedef struct
+{
+    int reserve;
+
+} OS_impl_timebase_internal_record_t;
+
+/****************************************************************************************
+                                   GLOBAL DATA
+ ***************************************************************************************/
+
+extern OS_impl_timebase_internal_record_t OS_impl_timebase_table[OS_MAX_TIMEBASES];
+
+
+#endif  /* INCLUDE_OS_IMPL_TIMEBASE_H_ */
+

--- a/osal/src/os/freertos/src/os-impl-binsem.c
+++ b/osal/src/os/freertos/src/os-impl-binsem.c
@@ -1,0 +1,175 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-binsem.c
+ * \ingroup  FreeRTOS
+ *
+ * Purpose: This file contains some of the OS APIs abstraction layer
+ *    implementation for POSIX
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-shared-binsem.h"
+
+
+
+/*---------------------------------------------------------------------------------------
+ * Helper function for acquiring the mutex when beginning a binary sem operation
+ * This uses timedlock to avoid waiting forever, and is put into a wrapper function
+ * to avoid pending forever.  The code should never pend on these for a long time.
+ ----------------------------------------------------------------------------------------*/
+int32 OS_Posix_BinSemAcquireMutex(pthread_mutex_t *mut)
+{
+
+    return OS_ERR_NOT_IMPLEMENTED;
+}
+
+/*---------------------------------------------------------------------------------------
+ * Helper function for releasing the mutex in case the thread
+ * executing pthread_condwait() is canceled.
+ ----------------------------------------------------------------------------------------*/
+void OS_Posix_BinSemReleaseMutex(void *mut)
+{
+
+}
+
+/****************************************************************************************
+                               BINARY SEMAPHORE API
+ ***************************************************************************************/
+
+
+/*---------------------------------------------------------------------------------------
+   Name: OS_Posix_BinSemAPI_Impl_Init
+
+   Purpose: Initialize the Binary Semaphore data structures
+
+ ----------------------------------------------------------------------------------------*/
+int32 OS_FreeRTOS_BinSemAPI_Impl_Init(void)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_BinSemAPI_Impl_Init */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_BinSemCreate_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemCreate_Impl (uint32 sem_id, uint32 initial_value, uint32 options)
+{
+
+    return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_BinSemCreate_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_BinSemDelete_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemDelete_Impl (uint32 sem_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_BinSemDelete_Impl */
+
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_BinSemGive_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemGive_Impl ( uint32 sem_id )
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_BinSemGive_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_BinSemFlush_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemFlush_Impl (uint32 sem_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_BinSemFlush_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_BinSemTake_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemTake_Impl ( uint32 sem_id )
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_BinSemTake_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_BinSemTimedWait_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemTimedWait_Impl ( uint32 sem_id, uint32 msecs )
+{
+
+ return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_BinSemTimedWait_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_BinSemGetInfo_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_BinSemGetInfo_Impl (uint32 sem_id, OS_bin_sem_prop_t *sem_prop)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_BinSemGetInfo_Impl */
+

--- a/osal/src/os/freertos/src/os-impl-common.c
+++ b/osal/src/os/freertos/src/os-impl-common.c
@@ -1,0 +1,72 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-common.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-shared-common.h"
+
+/*---------------------------------------------------------------------------------------
+   Name: OS_API_Impl_Init
+
+   Purpose: Initialize the tables that the OS API uses to keep track of information
+            about objects
+
+   returns: OS_SUCCESS or OS_ERROR
+---------------------------------------------------------------------------------------*/
+int32 OS_API_Impl_Init(uint32 idtype)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_API_Impl_Init */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_IdleLoop_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void OS_IdleLoop_Impl(void)
+{
+
+} /* end OS_IdleLoop_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_ApplicationShutdown_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void OS_ApplicationShutdown_Impl(void)
+{
+
+} /* end OS_ApplicationShutdown_Impl */

--- a/osal/src/os/freertos/src/os-impl-console.c
+++ b/osal/src/os/freertos/src/os-impl-console.c
@@ -1,0 +1,79 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-console.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-impl-console.h"
+#include "os-shared-printf.h"
+
+/*
+ * By default the console output is always asynchronous
+ * (equivalent to "OS_UTILITY_TASK_ON" being set)
+ *
+ * This option was removed from osconfig.h and now is
+ * assumed to always be on.
+ */
+#define OS_CONSOLE_ASYNC                true
+#define OS_CONSOLE_TASK_PRIORITY        OS_UTILITYTASK_PRIORITY
+
+
+/* Tables where the OS object information is stored */
+OS_impl_console_internal_record_t   OS_impl_console_table       [OS_MAX_CONSOLES];
+
+
+/********************************************************************/
+/*                 CONSOLE OUTPUT                                   */
+/********************************************************************/
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_ConsoleWakeup_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void  OS_ConsoleWakeup_Impl(uint32 local_id)
+{
+
+} /* end OS_ConsoleWakeup_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_ConsoleCreate_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_ConsoleCreate_Impl(uint32 local_id)
+{
+
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_ConsoleCreate_Impl */
+

--- a/osal/src/os/freertos/src/os-impl-countsem.c
+++ b/osal/src/os/freertos/src/os-impl-countsem.c
@@ -1,0 +1,155 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-countsem.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-impl-countsem.h"
+#include "os-shared-countsem.h"
+
+/*
+ * Added SEM_VALUE_MAX Define
+ */
+#ifndef SEM_VALUE_MAX
+#define SEM_VALUE_MAX       (UINT32_MAX/2)
+#endif
+
+/* Tables where the OS object information is stored */
+OS_impl_countsem_internal_record_t  OS_impl_count_sem_table     [OS_MAX_COUNT_SEMAPHORES];
+
+
+/****************************************************************************************
+                               COUNTING SEMAPHORE API
+ ***************************************************************************************/
+
+/*
+ * Unlike binary semaphores, counting semaphores can use the standard POSIX semaphore facility.
+ * This has the advantage of more correct behavior on "give" operations:
+ *  - give may be done from a signal / ISR context
+ *  - give should not cause an unexpected task switch nor should it ever block
+ */
+
+/*---------------------------------------------------------------------------------------
+   Name: OS_Posix_CountSemAPI_Impl_Init
+
+   Purpose: Initialize the Counting Semaphore data structures
+
+---------------------------------------------------------------------------------------*/
+int32 OS_FreeRTOS_CountSemAPI_Impl_Init(void)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_CountSemAPI_Impl_Init */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_CountSemCreate_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_CountSemCreate_Impl (uint32 sem_id, uint32 sem_initial_value, uint32 options)
+{
+        return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_CountSemCreate_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_CountSemDelete_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_CountSemDelete_Impl (uint32 sem_id)
+{
+
+    return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_CountSemDelete_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_CountSemGive_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_CountSemGive_Impl ( uint32 sem_id )
+{
+
+    return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_CountSemGive_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_CountSemTake_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_CountSemTake_Impl ( uint32 sem_id )
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_CountSemTake_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_CountSemTimedWait_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_CountSemTimedWait_Impl ( uint32 sem_id, uint32 msecs )
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_CountSemTimedWait_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_CountSemGetInfo_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_CountSemGetInfo_Impl (uint32 sem_id, OS_count_sem_prop_t *count_prop)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_CountSemGetInfo_Impl */
+

--- a/osal/src/os/freertos/src/os-impl-dirs.c
+++ b/osal/src/os/freertos/src/os-impl-dirs.c
@@ -1,0 +1,59 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-dirs.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-impl-dirs.h"
+#include "os-shared-dir.h"
+
+/****************************************************************************************
+                                     GLOBALS
+ ***************************************************************************************/
+
+/*
+ * The directory handle table.
+ */
+OS_impl_dir_internal_record_t OS_impl_dir_table[OS_MAX_NUM_OPEN_DIRS];
+
+/****************************************************************************************
+                         IMPLEMENTATION-SPECIFIC ROUTINES
+             These are specific to this particular operating system
+ ****************************************************************************************/
+
+/* --------------------------------------------------------------------------------------
+    Name: OS_Posix_DirAPI_Impl_Init
+
+    Purpose: Directory table initialization
+
+    Returns: OS_SUCCESS if success
+ ---------------------------------------------------------------------------------------*/
+int32 OS_FreeRTOS_DirAPI_Impl_Init(void)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_DirAPI_Impl_Init */
+

--- a/osal/src/os/freertos/src/os-impl-errors.c
+++ b/osal/src/os/freertos/src/os-impl-errors.c
@@ -1,0 +1,34 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-errors.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-shared-errors.h"
+
+const OS_ErrorTable_Entry_t OS_IMPL_ERROR_NAME_TABLE[] = { { 0, NULL } };
+

--- a/osal/src/os/freertos/src/os-impl-files.c
+++ b/osal/src/os/freertos/src/os-impl-files.c
@@ -1,0 +1,85 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-files.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-impl-files.h"
+#include "os-freertos.h"
+
+/****************************************************************************************
+                                     GLOBALS
+ ***************************************************************************************/
+
+/*
+ * The global file handle table.
+ *
+ * This is shared by all OSAL entities that perform low-level I/O.
+ */
+OS_FreeRTOS_filehandle_entry_t OS_impl_filehandle_table[OS_MAX_NUM_OPEN_FILES];
+
+
+/*
+ * These two constants (EUID and EGID) are local cache of the
+ * euid and egid of the user running the OSAL application.  They
+ * assist the "stat" implementation in determination of permissions.
+ *
+ * For an OS that does not have multiple users, these could be
+ * defined as 0.  Otherwise they should be populated via the system
+ * geteuid/getegid calls.
+ */
+uid_t OS_IMPL_SELF_EUID = 0;
+gid_t OS_IMPL_SELF_EGID = 0;
+
+/*
+ * Flag(s) to set on file handles for regular files
+ * This sets all regular filehandles to be non-blocking by default.
+ *
+ * In turn, the implementation will utilize select() to determine
+ * a filehandle readiness to read/write.
+ */
+const int OS_IMPL_REGULAR_FILE_FLAGS = O_NONBLOCK;
+
+
+/****************************************************************************************
+                         IMPLEMENTATION-SPECIFIC ROUTINES
+             These are specific to this particular operating system
+ ****************************************************************************************/
+
+/* --------------------------------------------------------------------------------------
+    Name: OS_FreeRTOS_StreamAPI_Impl_Init
+
+    Purpose: File/Stream subsystem global initialization
+
+    Returns: OS_SUCCESS if success
+ ---------------------------------------------------------------------------------------*/
+int32 OS_FreeRTOS_StreamAPI_Impl_Init(void)
+{
+
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_StreamAPI_Impl_Init */
+

--- a/osal/src/os/freertos/src/os-impl-filesys.c
+++ b/osal/src/os/freertos/src/os-impl-filesys.c
@@ -1,0 +1,163 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-filesys.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-shared-filesys.h"
+
+
+/****************************************************************************************
+                                     DEFINES
+ ***************************************************************************************/
+
+/****************************************************************************************
+                                   GLOBAL DATA
+ ***************************************************************************************/
+const char OS_FREERTOS_DEVICEFILE_PREFIX[] = "/dev/";
+
+/****************************************************************************************
+                                Filesys API
+ ***************************************************************************************/
+
+/* --------------------------------------------------------------------------------------
+    Name: OS_Posix_FileSysAPI_Impl_Init
+
+    Purpose: Filesystem API global initialization
+
+    Returns: OS_SUCCESS if success
+ ---------------------------------------------------------------------------------------*/
+int32 OS_FreeRTOS_FileSysAPI_Impl_Init(void)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_FileSysAPI_Impl_Init */
+
+
+/*
+ * System Level API
+ */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FileSysStartVolume_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FileSysStartVolume_Impl (uint32 filesys_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_FileSysStartVolume_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FileSysStopVolume_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FileSysStopVolume_Impl (uint32 filesys_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_FileSysStopVolume_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FileSysFormatVolume_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FileSysFormatVolume_Impl (uint32 filesys_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_FileSysFormatVolume_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FileSysMountVolume_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FileSysMountVolume_Impl (uint32 filesys_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_FileSysMountVolume_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FileSysUnmountVolume_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FileSysUnmountVolume_Impl (uint32 filesys_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+
+} /* end OS_FileSysUnmountVolume_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FileSysStatVolume_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FileSysStatVolume_Impl (uint32 filesys_id, OS_statvfs_t *result)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_FileSysStatVolume_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FileSysCheckVolume_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FileSysCheckVolume_Impl (uint32 filesys_id, bool repair)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_FileSysCheckVolume_Impl */
+

--- a/osal/src/os/freertos/src/os-impl-fpu.c
+++ b/osal/src/os/freertos/src/os-impl-fpu.c
@@ -1,0 +1,105 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-fpu.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-shared-fpu.h"
+
+/****************************************************************************************
+                                    FPU API (deprecated)
+ ***************************************************************************************/
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FPUExcAttachHandler_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FPUExcAttachHandler_Impl(uint32 ExceptionNumber, osal_task_entry ExceptionHandler,
+                                 int32 parameter)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_FPUExcAttachHandler_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FPUExcEnable_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FPUExcEnable_Impl(int32 ExceptionNumber)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_FPUExcEnable_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FPUExcDisable_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FPUExcDisable_Impl(int32 ExceptionNumber)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_FPUExcDisable_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FPUExcSetMask_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FPUExcSetMask_Impl(uint32 mask)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_FPUExcSetMask_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_FPUExcGetMask_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FPUExcGetMask_Impl(uint32 *mask)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_FPUExcGetMask_Impl */
+

--- a/osal/src/os/freertos/src/os-impl-heap.c
+++ b/osal/src/os/freertos/src/os-impl-heap.c
@@ -1,0 +1,45 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-heap.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-shared-heap.h"
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_HeapGetInfo_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_HeapGetInfo_Impl(OS_heap_prop_t *heap_prop)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_HeapGetInfo_Impl */
+

--- a/osal/src/os/freertos/src/os-impl-idmap.c
+++ b/osal/src/os/freertos/src/os-impl-idmap.c
@@ -1,0 +1,74 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-idmap.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+
+#include "os-shared-idmap.h"
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_Lock_Global_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_Lock_Global_Impl(uint32 idtype)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Lock_Global_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_Unlock_Global_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_Unlock_Global_Impl(uint32 idtype)
+{
+  return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Unlock_Global_Impl */
+
+
+/*---------------------------------------------------------------------------------------
+   Name: OS_Posix_TableMutex_Init
+
+   Purpose: Initialize the mutex that the OS API uses for the shared state tables
+
+   returns: OS_SUCCESS or OS_ERROR
+---------------------------------------------------------------------------------------*/
+int32 OS_FreeRTOS_TableMutex_Init(uint32 idtype)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_TableMutex_Init */
+

--- a/osal/src/os/freertos/src/os-impl-interrupts.c
+++ b/osal/src/os/freertos/src/os-impl-interrupts.c
@@ -1,0 +1,133 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-interrupts.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-shared-interrupts.h"
+
+/****************************************************************************************
+                                    INT API (deprecated)
+ ***************************************************************************************/
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_IntAttachHandler_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_IntAttachHandler_Impl  (uint32 InterruptNumber, osal_task_entry InterruptHandler, int32 parameter)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_IntAttachHandler_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_IntUnlock_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_IntUnlock_Impl (int32 IntLevel)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_IntUnlock_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_IntLock_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_IntLock_Impl ( void )
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_IntLock_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_IntEnable_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_IntEnable_Impl(int32 Level)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_IntEnable_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_IntDisable_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_IntDisable_Impl(int32 Level)
+{
+    return(OS_ERR_NOT_IMPLEMENTED);
+} /* end OS_IntDisable_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_IntSetMask_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_IntSetMask_Impl ( uint32 MaskSetting )
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_IntSetMask_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_IntGetMask_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_IntGetMask_Impl ( uint32 * MaskSettingPtr )
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_IntGetMask_Impl */
+

--- a/osal/src/os/freertos/src/os-impl-loader.c
+++ b/osal/src/os/freertos/src/os-impl-loader.c
@@ -1,0 +1,48 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-loader.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-impl-loader.h"
+#include "os-shared-module.h"
+
+OS_impl_module_internal_record_t OS_impl_module_table[OS_MAX_MODULES];
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_Posix_ModuleAPI_Impl_Init
+ *
+ *  Purpose: Local helper routine, not part of OSAL API.
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FreeRTOS_ModuleAPI_Impl_Init(void)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_ModuleAPI_Impl_Init */
+
+

--- a/osal/src/os/freertos/src/os-impl-mutex.c
+++ b/osal/src/os/freertos/src/os-impl-mutex.c
@@ -1,0 +1,125 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-mutex.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-shared-mutex.h"
+#include "os-impl-mutex.h"
+
+
+/* Tables where the OS object information is stored */
+OS_impl_mutex_internal_record_t   OS_impl_mutex_table       [OS_MAX_MUTEXES];
+
+
+/****************************************************************************************
+                                  MUTEX API
+ ***************************************************************************************/
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_Posix_MutexAPI_Impl_Init
+ *
+ *  Purpose: Local helper routine, not part of OSAL API.
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FreeRTOS_MutexAPI_Impl_Init(void)
+{
+      return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_MutexAPI_Impl_Init */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_MutSemCreate_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_MutSemCreate_Impl (uint32 sem_id, uint32 options)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_MutSemCreate_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_MutSemDelete_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_MutSemDelete_Impl (uint32 sem_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_MutSemDelete_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_MutSemGive_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_MutSemGive_Impl ( uint32 sem_id )
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_MutSemGive_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_MutSemTake_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_MutSemTake_Impl ( uint32 sem_id )
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_MutSemTake_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_MutSemGetInfo_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_MutSemGetInfo_Impl (uint32 sem_id, OS_mut_sem_prop_t *mut_prop)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_MutSemGetInfo_Impl */
+

--- a/osal/src/os/freertos/src/os-impl-no-module.c
+++ b/osal/src/os/freertos/src/os-impl-no-module.c
@@ -1,0 +1,46 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-no-module.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include <osapi.h>
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_Posix_ModuleAPI_Impl_Init
+ *
+ *  Purpose: Local helper routine, not part of OSAL API.
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_FreeRTOS_ModuleAPI_Impl_Init(void)
+{
+    /* nothing to init in this mode */
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_FreeRTOS_ModuleAPI_Impl_Init */
+
+

--- a/osal/src/os/freertos/src/os-impl-queues.c
+++ b/osal/src/os/freertos/src/os-impl-queues.c
@@ -1,0 +1,110 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-queues.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-impl-queues.h"
+#include "os-shared-queue.h"
+
+/* Tables where the OS object information is stored */
+OS_impl_queue_internal_record_t     OS_impl_queue_table         [OS_MAX_QUEUES];
+
+/****************************************************************************************
+                                MESSAGE QUEUE API
+ ***************************************************************************************/
+
+/*---------------------------------------------------------------------------------------
+   Name: OS_Posix_QueueAPI_Impl_Init
+
+   Purpose: Initialize the Queue data structures
+
+ ----------------------------------------------------------------------------------------*/
+int32 OS_FreeRTOS_QueueAPI_Impl_Init(void)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_QueueAPI_Impl_Init */
+
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_QueueCreate_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_QueueCreate_Impl (uint32 queue_id, uint32 flags)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_QueueCreate_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_QueueDelete_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_QueueDelete_Impl (uint32 queue_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_QueueDelete_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_QueueGet_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_QueueGet_Impl (uint32 queue_id, void *data, uint32 size, uint32 *size_copied, int32 timeout)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_QueueGet_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_QueuePut_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_QueuePut_Impl (uint32 queue_id, const void *data, uint32 size, uint32 flags)
+{
+
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_QueuePut_Impl */
+
+

--- a/osal/src/os/freertos/src/os-impl-shell.c
+++ b/osal/src/os/freertos/src/os-impl-shell.c
@@ -1,0 +1,57 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-shell.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-shared-shell.h"
+
+/****************************************************************************************
+                                     GLOBALS
+ ***************************************************************************************/
+
+
+
+/****************************************************************************************
+                         IMPLEMENTATION-SPECIFIC ROUTINES
+             These are specific to this particular operating system
+ ****************************************************************************************/
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_ShellOutputToFile_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_ShellOutputToFile_Impl(uint32 file_id, const char* Cmd)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_ShellOutputToFile_Impl */
+

--- a/osal/src/os/freertos/src/os-impl-tasks.c
+++ b/osal/src/os/freertos/src/os-impl-tasks.c
@@ -1,0 +1,210 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-tasks.c
+ * \ingroup  FreeRTOS
+ *
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-impl-tasks.h"
+#include "os-freertos.h"
+#include "os-shared-task.h"
+
+/* Tables where the OS object information is stored */
+OS_impl_task_internal_record_t      OS_impl_task_table          [OS_MAX_TASKS];
+
+
+/*
+ *********************************************************************************
+ *          TASK API
+ *********************************************************************************
+ */
+
+/*---------------------------------------------------------------------------------------
+   Name: OS_Posix_TaskAPI_Impl_Init
+
+   Purpose: Initialize the Posix Task data structures
+
+ ----------------------------------------------------------------------------------------*/
+int32 OS_FreeRTOS_TaskAPI_Impl_Init(void)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_TaskAPI_Impl_Init */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskCreate_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskCreate_Impl (uint32 task_id, uint32 flags)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TaskCreate_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskMatch_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskMatch_Impl(uint32 task_id)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TaskMatch_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskDelete_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskDelete_Impl (uint32 task_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TaskDelete_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskExit_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void OS_TaskExit_Impl()
+{
+
+} /* end OS_TaskExit_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskDelay_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskDelay_Impl(uint32 millisecond)
+{
+  return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TaskDelay_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskSetPriority_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskSetPriority_Impl (uint32 task_id, uint32 new_priority)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TaskSetPriority_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskRegister_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskRegister_Impl(uint32 global_task_id)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TaskRegister_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskGetId_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+uint32 OS_TaskGetId_Impl (void)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TaskGetId_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskGetInfo_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskGetInfo_Impl (uint32 task_id, OS_task_prop_t *task_prop)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TaskGetInfo_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskIdMatchSystemData_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+bool OS_TaskIdMatchSystemData_Impl(void *ref, uint32 local_id, const OS_common_record_t *obj)
+{
+    return false;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TaskValidateSystemData_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TaskValidateSystemData_Impl(const void *sysdata, uint32 sysdata_size)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+}
+
+
+

--- a/osal/src/os/freertos/src/os-impl-timebase.c
+++ b/osal/src/os/freertos/src/os-impl-timebase.c
@@ -1,0 +1,173 @@
+/*
+ *  NASA Docket No. GSC-18,370-1, and identified as "Operating System Abstraction Layer"
+ *
+ *  Copyright (c) 2019 United States Government as represented by
+ *  the Administrator of the National Aeronautics and Space Administration.
+ *  All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/**
+ * \file     os-impl-timebase.c
+ * \ingroup  FreeRTOS
+ */
+
+/****************************************************************************************
+                                    INCLUDE FILES
+ ***************************************************************************************/
+
+#include "os-impl-timebase.h"
+#include "os-freertos.h"
+
+
+/****************************************************************************************
+                                EXTERNAL FUNCTION PROTOTYPES
+ ***************************************************************************************/
+
+/****************************************************************************************
+                                INTERNAL FUNCTION PROTOTYPES
+ ***************************************************************************************/
+
+
+/****************************************************************************************
+                                     DEFINES
+ ***************************************************************************************/
+
+/*
+ * Prefer to use the MONOTONIC clock if available, as it will not get distrupted by setting
+ * the time like the REALTIME clock will.
+ */
+#ifndef OS_PREFERRED_CLOCK
+#ifdef  _POSIX_MONOTONIC_CLOCK
+#define OS_PREFERRED_CLOCK      CLOCK_MONOTONIC
+#else
+#define OS_PREFERRED_CLOCK      CLOCK_REALTIME
+#endif
+#endif
+
+/****************************************************************************************
+                                     GLOBALS
+ ***************************************************************************************/
+
+OS_impl_timebase_internal_record_t OS_impl_timebase_table[OS_MAX_TIMEBASES];
+
+/****************************************************************************************
+                                INTERNAL FUNCTIONS
+ ***************************************************************************************/
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TimeBaseLock_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void OS_TimeBaseLock_Impl(uint32 local_id)
+{
+
+} /* end OS_TimeBaseLock_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TimeBaseUnlock_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void OS_TimeBaseUnlock_Impl(uint32 local_id)
+{
+
+} /* end OS_TimeBaseUnlock_Impl */
+
+
+/****************************************************************************************
+                                INITIALIZATION FUNCTION
+ ***************************************************************************************/
+
+/******************************************************************************
+ *  Function:  OS_Posix_TimeBaseAPI_Impl_Init
+ *
+ *  Purpose:  Initialize the timer implementation layer
+ *
+ *  Arguments:
+ *
+ *  Return:
+ */
+int32 OS_FreeRTOS_TimeBaseAPI_Impl_Init(void)
+{
+   return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_Posix_TimeBaseAPI_Impl_Init */
+
+/****************************************************************************************
+                                   Time Base API
+ ***************************************************************************************/
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TimeBaseCreate_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TimeBaseCreate_Impl(uint32 timer_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TimeBaseCreate_Impl */
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TimeBaseSet_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TimeBaseSet_Impl(uint32 timer_id, int32 start_time, int32 interval_time)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TimeBaseSet_Impl */
+
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TimeBaseDelete_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TimeBaseDelete_Impl(uint32 timer_id)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TimeBaseDelete_Impl */
+
+
+/*----------------------------------------------------------------
+ *
+ * Function: OS_TimeBaseGetInfo_Impl
+ *
+ *  Purpose: Implemented per internal OSAL API
+ *           See prototype for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 OS_TimeBaseGetInfo_Impl (uint32 timer_id, OS_timebase_prop_t *timer_prop)
+{
+    return OS_ERR_NOT_IMPLEMENTED;
+} /* end OS_TimeBaseGetInfo_Impl */
+

--- a/psp/fsw/arm-freertos/CMakeLists.txt
+++ b/psp/fsw/arm-freertos/CMakeLists.txt
@@ -1,0 +1,22 @@
+######################################################################
+#
+# CMAKE build recipe for arm-freertos PSP component
+#
+######################################################################
+
+# This contains the fully platform-specific code to 
+# run CFE on this target.
+
+include_directories(inc) 
+
+# Build the arm-freertos implementation as a library
+add_library(psp-${CFE_PSP_TARGETNAME}-impl OBJECT
+    src/cfe_psp_exception.c
+    src/cfe_psp_memory.c
+    src/cfe_psp_memtab.c
+    src/cfe_psp_ssr.c
+    src/cfe_psp_start.c
+    src/cfe_psp_support.c
+    src/cfe_psp_timer.c
+    src/cfe_psp_watchdog.c)
+

--- a/psp/fsw/arm-freertos/inc/cfe_psp_config.h
+++ b/psp/fsw/arm-freertos/inc/cfe_psp_config.h
@@ -1,0 +1,149 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** cfe_psp_config.h
+*/
+
+#ifndef _cfe_psp_config_
+#define _cfe_psp_config_
+
+
+
+#include "common_types.h"
+
+#include <signal.h>
+#include <time.h>
+#include <pthread.h>
+
+/*
+** This define sets the number of memory ranges that are defined in the memory range defintion
+** table.
+*/
+#define CFE_PSP_MEM_TABLE_SIZE 10
+
+/**
+ * This define sets the maximum number of exceptions
+ * that can be stored.
+ *
+ * It must always be a power of two.
+ */
+#define CFE_PSP_MAX_EXCEPTION_ENTRIES           4
+#define CFE_PSP_MAX_EXCEPTION_BACKTRACE_SIZE    16
+
+
+/*
+ * A random 32-bit value that is used as the "validity flag"
+ * of the PC-Linux boot record structure.  This is simply
+ * a value that is unlikely to occur unless specifically set.
+ */
+#define CFE_PSP_BOOTRECORD_VALID            ((uint32)0x2aebe984)
+#define CFE_PSP_BOOTRECORD_INVALID          (~CFE_PSP_BOOTRECORD_VALID)
+
+/*
+ * The amount of time to wait for an orderly shutdown
+ * in the event of a call to CFE_PSP_Restart()
+ *
+ * If this expires, then an abnormal exit/abort() is triggered.
+ */
+#define CFE_PSP_RESTART_DELAY               10000
+
+/* use the "USR1" signal to wake the idle thread when an exception occurs */
+#define CFE_PSP_EXCEPTION_EVENT_SIGNAL      SIGUSR1
+
+
+/*
+** Global variables
+*/
+
+/*
+** Typedef for the header structure on the reserved memory block
+**
+** Note that the structure below reserves memory sizes defined
+** at compile time directly from cfe_platform_cfg.h above.
+** A future enhancement should reserve blocks based on the runtime
+** size in GLOBAL_CONFIGDATA.
+*/
+typedef struct
+{
+    uint32 ValidityFlag;
+    uint32 NextResetType;
+
+} CFE_PSP_ReservedMemoryBootRecord_t;
+
+/*
+ * The state of the PSP "idle task"
+ *
+ * This is the main/initial thread that runs early init,
+ * it is NOT an OSAL task.
+ *
+ * Once initialized, this thread goes idle and waits for
+ * asynchronous events to occur, and resumes with an orderly
+ * shutdown if requested.
+ */
+typedef struct
+{
+    pthread_t ThreadID;
+    volatile bool ShutdownReq;
+} CFE_PSP_IdleTaskState_t;
+
+
+
+/**
+ * \brief The data type used by the underlying OS to represent a thread ID.
+ */
+typedef pthread_t CFE_PSP_Exception_SysTaskId_t;
+
+/**
+ * \brief Exception context data which is relevant for offline/post-mortem diagnosis.
+ *
+ * This may be stored in a persistent exception log file for later analysis.
+ */
+typedef struct
+{
+    struct timespec event_time;
+    siginfo_t si;
+
+    /*
+     * Note this is a variably-filled array based on the number of addresses
+     * reported by the library.  It should be last.
+     */
+    void *bt_addrs[CFE_PSP_MAX_EXCEPTION_BACKTRACE_SIZE];
+} CFE_PSP_Exception_ContextDataEntry_t;
+
+/*
+** Watchdog minimum and maximum values ( in milliseconds )
+*/
+#define CFE_PSP_WATCHDOG_MIN (0)
+#define CFE_PSP_WATCHDOG_MAX (0xFFFFFFFF) 
+
+/*
+** Number of EEPROM banks on this platform
+*/
+#define CFE_PSP_NUM_EEPROM_BANKS 1
+
+/*
+ * Information about the "idle task" --
+ * this is used by exception handling to wake it when an event occurs
+ */
+extern CFE_PSP_IdleTaskState_t  CFE_PSP_IdleTaskState;
+
+#endif
+

--- a/psp/fsw/arm-freertos/inc/psp_version.h
+++ b/psp/fsw/arm-freertos/inc/psp_version.h
@@ -1,0 +1,63 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*! @file pc-linux/inc/psp_version.h
+ *  @brief Purpose: 
+ *  @details Provide version identifiers for the cFE Platform Support Packages (PSP).   
+ *  See @ref cfsversions for version and build number and description
+ */
+#ifndef _psp_version_
+#define _psp_version_
+
+/*
+ * Development Build Macro Definitions 
+ */
+#define CFE_PSP_IMPL_BUILD_NUMBER 71
+#define CFE_PSP_IMPL_BUILD_BASELINE "v1.4.0+dev"
+
+/*
+ * Version Macro Definitions
+ */
+#define CFE_PSP_IMPL_MAJOR_VERSION 1 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
+#define CFE_PSP_IMPL_MINOR_VERSION 4 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
+#define CFE_PSP_IMPL_REVISION      0 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision number. */
+#define CFE_PSP_IMPL_MISSION_REV   0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+
+/*
+ * Tools to construct version string
+ */ 
+#define CFE_PSP_IMPL_STR_HELPER(x) #x /*!< @brief Helper function to concatenate strings from integer */ 
+#define CFE_PSP_IMPL_STR(x)        CFE_PSP_IMPL_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer */
+
+/*! @brief Development Build Version Number. 
+ *  @details Baseline git tag + Number of commits since baseline. @n
+ *  See @ref cfsversions for format differences between development and release versions.
+ */
+#define CFE_PSP_IMPL_VERSION CFE_PSP_IMPL_BUILD_BASELINE CFE_PSP_IMPL_STR(CFE_PSP_IMPL_BUILD_NUMBER)
+
+/*! @brief Development Build Version String.
+ *  @details Reports the current development build's baseline, number, and name. Also includes a note about the latest official version. @n
+ *  See @ref cfsversions for format differences between development and release versions. 
+ */     
+#define CFE_PSP_IMPL_VERSION_STRING                                                                      \
+    " PSP Development Build\n " CFE_PSP_IMPL_VERSION " (Codename: Bootes)" /* Codename for current development */ \
+    "\n Last Official Release: psp v1.4.0"                        /* For full support please use this version */
+
+#endif  /* _psp_version_ */

--- a/psp/fsw/arm-freertos/make/build_options.cmake
+++ b/psp/fsw/arm-freertos/make/build_options.cmake
@@ -1,0 +1,18 @@
+##########################################################################
+#
+# Build options for "arm-freertos" PSP
+# This file specifies any global-scope compiler options when using this PSP
+#
+##########################################################################
+
+# This indicates where to install target binaries created during the build
+# Note - this should be phased out in favor of the staging dir from OSAL BSP
+set(INSTALL_SUBDIR "cf")
+
+# Some upper-level code may be gated on _LINUX_OS_ being defined
+# This is for compatibility with older build scripts which defined this symbol,
+# but no CFE/OSAL framework code depends on this symbol.
+add_definitions("-D_LINUX_OS_")
+
+set(CFE_PSP_EXPECTED_OSAL_BSPTYPE "arm-freertos")
+

--- a/psp/fsw/arm-freertos/make/compiler-opts.mak
+++ b/psp/fsw/arm-freertos/make/compiler-opts.mak
@@ -1,0 +1,95 @@
+##############################################################################
+## compiler-opts.mak - compiler definitions and options for building the cFE 
+##
+## Target: x86 PC Linux
+##
+## Modifications:
+##
+###############################################################################
+## 
+## Warning Level Configuration
+##
+# WARNINGS=-Wall -ansi -pedantic -Wstrict-prototypes
+WARNINGS=-Wall -Wstrict-prototypes
+
+## 
+## Host OS Include Paths ( be sure to put the -I switch in front of each directory )
+##
+SYSINCS=
+
+##
+## Target Defines for the OS, Hardware Arch, etc..
+##
+TARGET_DEFS+=-D__ix86__ -D_ix86_ -D_LINUX_OS_  -D$(OS) -DX86PC -DBUILD=$(BUILD) -D_REENTRANT -D _EMBED_  
+
+## 
+## Endian Defines
+##
+ENDIAN_DEFS=-D_EL -DENDIAN=_EL -DSOFTWARE_LITTLE_BIT_ORDER 
+
+##
+## Compiler Architecture Switches
+## 
+ARCH_OPTS = -m32
+
+##
+## Application specific compiler switches 
+##
+ifeq ($(BUILD_TYPE),CFE_APP)
+   APP_COPTS= 
+   APP_ASOPTS=
+else
+   APP_COPTS=
+   APP_ASOPTS=
+endif
+
+##
+## Extra Cflags for Assembly listings, etc.
+##
+LIST_OPTS = 
+
+##
+## gcc options for dependancy generation
+## 
+COPTS_D = $(APP_COPTS) $(ENDIAN_DEFS) $(TARGET_DEFS) $(ARCH_OPTS) $(SYSINCS) $(WARNINGS)
+
+## 
+## General gcc options that apply to compiling and dependency generation.
+##
+COPTS=$(LIST_OPTS) $(COPTS_D)
+
+##
+## Extra defines and switches for assembly code
+##
+ASOPTS = $(APP_ASOPTS) -P -xassembler-with-cpp 
+
+##---------------------------------------------------------
+## Application file extention type
+## This is the defined application extention.
+## Known extentions: Mac OS X: .bundle, Linux: .so, RTEMS:
+##   .s3r, vxWorks: .o etc.. 
+##---------------------------------------------------------
+APP_EXT = so
+
+#################################################################################
+## Host Development System and Toolchain defintions
+##
+
+##
+## Host OS utils
+##
+RM=rm -f
+CP=cp
+
+##
+## Compiler tools
+##
+COMPILER=gcc
+ASSEMBLER=as
+LINKER=ld -melf_i386 
+AR=ar
+NM=nm
+SIZE=size
+OBJCOPY=objcopy
+OBJDUMP=objdump
+TABLE_BIN = elf2cfetbl

--- a/psp/fsw/arm-freertos/make/link-rules.mak
+++ b/psp/fsw/arm-freertos/make/link-rules.mak
@@ -1,0 +1,42 @@
+###############################################################################
+# File: link-rules.mak
+#
+# Purpose:
+#   Makefile for linking code and producing the cFE Core executable image.
+#
+# History:
+#
+###############################################################################
+##
+## Executable target. This is target specific
+##
+EXE_TARGET=core-freertos.bin
+
+CORE_INSTALL_FILES = $(EXE_TARGET)
+
+
+##
+## Linker flags that are needed
+##
+LDFLAGS = -m32 -Wl,-export-dynamic
+
+##
+## Libraries to link in
+##
+LIBS =  -lm -lpthread -ldl -lrt
+##
+## Uncomment the following line to link in C++ standard libs
+## LIBS += -lstdc++
+## 
+
+##
+## cFE Core Link Rule
+## 
+$(EXE_TARGET): $(CORE_OBJS)
+	$(COMPILER) $(DEBUG_FLAGS) -o $(EXE_TARGET) $(CORE_OBJS) $(LDFLAGS) $(LIBS)
+	
+##
+## Application Link Rule
+##
+$(APPTARGET).$(APP_EXT): $(OBJS)
+	$(COMPILER) -m32 -shared -o $@ $(OBJS) 

--- a/psp/fsw/arm-freertos/src/cfe_psp_exception.c
+++ b/psp/fsw/arm-freertos/src/cfe_psp_exception.c
@@ -1,0 +1,344 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+S
+** File:  cfe_psp_exception.c
+**
+**      POSIX ( Mac OS X, Linux, Cygwin ) version
+**
+** Purpose:
+**   cFE PSP Exception handling functions
+**
+** History:
+**   2007/05/29  A. Cudmore      | POSIX Version
+**
+******************************************************************************/
+
+/*
+**  Include Files
+*/
+#include <stdio.h>
+#include <string.h>
+#include <pthread.h>
+
+/*
+** cFE includes
+*/
+#include "common_types.h"
+#include "osapi.h"
+#include "cfe_psp.h"
+#include "cfe_psp_config.h"
+#include "cfe_psp_exceptionstorage_types.h"
+#include "cfe_psp_exceptionstorage_api.h"
+
+#include <execinfo.h>
+#include <signal.h>
+
+/*
+ * A set of asynchronous signals which will be masked during other signal processing
+ */
+sigset_t    CFE_PSP_AsyncMask;
+
+
+
+
+/***************************************************************************
+ **                        FUNCTIONS DEFINITIONS
+ ***************************************************************************/
+
+
+/*
+** Name: CFE_PSP_ExceptionSigHandler
+**
+** Installed as a signal handler to log exception events.
+**
+*/
+void CFE_PSP_ExceptionSigHandler (int signo, siginfo_t *si, void *ctxt)
+{
+    CFE_PSP_Exception_LogData_t* Buffer;
+    int NumAddrs;
+
+    /*
+     * Note that the time between CFE_PSP_Exception_GetNextContextBuffer()
+     * and CFE_PSP_Exception_WriteComplete() is sensitive in that it is
+     * accessing a global.
+     *
+     * Cannot use a conventional lock because this is a signal handler, the
+     * solution would need to involve a signal-safe spinlock and/or C11
+     * atomic ops.
+     *
+     * This means if another exception occurs on another task during this
+     * time window, it may use the same buffer.
+     *
+     * However, exceptions should be rare enough events that this is highly
+     * unlikely to occur, so leaving this unhandled for now.
+     */
+    Buffer = CFE_PSP_Exception_GetNextContextBuffer();
+    if (Buffer != NULL)
+    {
+        /*
+         * read the clock as a timestamp - note "clock_gettime" is signal safe per POSIX,
+         *
+         * _not_ going through OSAL to read this as it may do something signal-unsafe...
+         * (current implementation would be safe, but it is not guaranteed to always be).
+         */
+        clock_gettime(CLOCK_MONOTONIC, &Buffer->context_info.event_time);
+        memcpy(&Buffer->context_info.si, si, sizeof(Buffer->context_info.si));
+        NumAddrs = backtrace(Buffer->context_info.bt_addrs, CFE_PSP_MAX_EXCEPTION_BACKTRACE_SIZE);
+        Buffer->context_size = offsetof(CFE_PSP_Exception_ContextDataEntry_t, bt_addrs[NumAddrs]);
+        /* pthread_self() is signal-safe per POSIX.1-2013 */
+        Buffer->sys_task_id = pthread_self();
+        CFE_PSP_Exception_WriteComplete();
+    }
+
+    /*
+     * notify the main (idle) thread that an interesting event occurred.
+     * Note on this platform this cannot _directly_ invoke CFE from a signal handler.
+     */
+    pthread_kill(CFE_PSP_IdleTaskState.ThreadID, CFE_PSP_EXCEPTION_EVENT_SIGNAL);
+}
+
+/*
+** Name: CFE_PSP_ExceptionSigHandlerSuspend
+**
+** An extension of CFE_PSP_ExceptionSigHandler that also
+** suspends the calling task and prevents returning to the
+** application.
+**
+** This is required for handling events like Floating Point exceptions,
+** where returning to the application would resume at the same instruction
+** and re-trigger the exception, resulting in a loop.
+**
+*/
+void CFE_PSP_ExceptionSigHandlerSuspend (int signo, siginfo_t *si, void *ctxt)
+{
+    /*
+     * Perform normal exception logging
+     */
+    CFE_PSP_ExceptionSigHandler(signo, si, ctxt);
+
+    /*
+     * calling "sigsuspend" with an empty mask should
+     * block this thread indefinitely.  This is intended
+     * to replicate the behavior of vxworks which suspends
+     * the task after an exception.
+     *
+     * This stops execution of the thread in anticipation that it
+     * will be deleted by the CFE/OSAL.
+     */
+    sigsuspend(&CFE_PSP_AsyncMask);
+
+} /* end function */
+
+/*
+ * Helper function to call sigaction() to attach a signal handler
+ */
+void CFE_PSP_AttachSigHandler (int signo)
+{
+    struct sigaction sa;
+
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_mask = CFE_PSP_AsyncMask;
+
+    if(!sigismember(&CFE_PSP_AsyncMask, signo))
+    {
+        /*
+         * In the event that the handler is being installed for one of the
+         * synchronous events, use the CFE_PSP_ExceptionSigHandlerSuspend variant.
+         *
+         * This suspends the caller and prevents returning to the application.
+         */
+        sa.sa_sigaction = CFE_PSP_ExceptionSigHandlerSuspend;
+
+        /*
+         * add it back to the mask set.
+         * This is supposed to be default unless SA_NODEFER flag is set,
+         * but also setting it here to be sure.
+         */
+        sigaddset(&sa.sa_mask, signo);
+    }
+    else
+    {
+        /*
+         * Use default handler which will return to the application
+         * after logging the event
+         */
+        sa.sa_sigaction = CFE_PSP_ExceptionSigHandler;
+    }
+    sa.sa_flags = SA_SIGINFO;
+
+    sigaction(signo, &sa, NULL);
+}
+
+
+
+/*
+**   Name: CFE_PSP_AttachExceptions
+**
+**   This is called from the CFE Main task, before any other threads
+**   are started.  Use this opportunity to install the handler for
+**   CTRL+C events, which will now be treated as an exception.
+**
+**   Not only does this clean up the code by NOT requiring a specific
+**   handler for CTRL+C, it also provides a way to exercise and test
+**   the exception handling in general, which tends to be infrequently
+**   invoked because otherwise it only happens with off nominal behavior.
+**
+**   This has yet another benefit that SIGINT events will make their
+**   way into the exception and reset log, so it is visible why the
+**   CFE shut down.
+*/
+
+void CFE_PSP_AttachExceptions(void)
+{
+    void *Addr[1];
+
+    /*
+     * preemptively call "backtrace" -
+     * The manpage notes that backtrace is implemented in libgcc
+     * which may be dynamically linked with lazy binding. So
+     * by calling it once we ensure that it is loaded and therefore
+     * it is safe to use in a signal handler.
+     */
+    backtrace(Addr, 1);
+
+    OS_printf("CFE_PSP: CFE_PSP_AttachExceptions Called\n");
+
+    /*
+     * Block most other signals during handler execution.
+     * Exceptions are for synchronous errors SIGFPE/SIGSEGV/SIGILL/SIGBUS
+     */
+    sigfillset(&CFE_PSP_AsyncMask);
+    sigdelset(&CFE_PSP_AsyncMask, SIGILL);
+    sigdelset(&CFE_PSP_AsyncMask, SIGFPE);
+    sigdelset(&CFE_PSP_AsyncMask, SIGBUS);
+    sigdelset(&CFE_PSP_AsyncMask, SIGSEGV);
+
+    /*
+     * Install sigint_handler as the signal handler for SIGINT.
+     *
+     * In the event that the user presses CTRL+C at the console
+     * this will be recorded as an exception and use the general
+     * purpose exception processing logic to shut down CFE.
+     *
+     * Also include SIGTERM so it will invoke a graceful shutdown
+     */
+    CFE_PSP_AttachSigHandler(SIGINT);
+    CFE_PSP_AttachSigHandler(SIGTERM);
+
+    /*
+     * Clear any pending exceptions.
+     *
+     * This is just in case this is a PROCESSOR reset and there
+     * was something still in the queue from the last lifetime.
+     *
+     * It should have been logged already, but if not, then
+     * don't action on it now.
+     */
+    CFE_PSP_Exception_Reset();
+}
+
+/*
+**
+**   Name: CFE_PSP_SetDefaultExceptionEnvironment
+**
+**   Purpose: This function sets a default exception environment that can be used
+**
+**   Notes: The exception environment is local to each task Therefore this must be
+**          called for each task that that wants to do floating point and catch exceptions
+**          Currently, this is automaticall called from OS_TaskRegister for every task
+*/
+
+void CFE_PSP_SetDefaultExceptionEnvironment(void)
+{
+    /*
+     * This additionally sets a handler for SIGFPE which will catch arithmetic errors
+     * such as divide by zero.  Other possibilities are SIGILL/SIGBUS/SIGSEGV.
+     *
+     * This is primarily used as a proof-of-concept on this platform to demonstrate
+     * how the exception handling feature works.
+     *
+     * As the PC-Linux platform is often used for debugging, it is better to
+     * maintain the default signal handler for the SIGILL/SIGBUS/SIGSEGV which will
+     * abort the program and generate a core file.
+     */
+    CFE_PSP_AttachSigHandler(SIGFPE);
+}
+
+int32 CFE_PSP_ExceptionGetSummary_Impl(const CFE_PSP_Exception_LogData_t* Buffer, char *ReasonBuf, uint32 ReasonSize)
+{
+    const char *ComputedReason = "unknown";
+
+    /* check the "code" within the siginfo structure, which reveals more info about the FP exception */
+    if (Buffer->context_info.si.si_signo == SIGFPE)
+    {
+        switch(Buffer->context_info.si.si_code)
+        {
+        case FPE_INTDIV:
+            ComputedReason = "Integer divide by zero";
+            break;
+        case FPE_INTOVF:
+            ComputedReason = "Integer overflow";
+            break;
+        case FPE_FLTDIV:
+            ComputedReason = "Floating-point divide by zero";
+            break;
+        case FPE_FLTOVF:
+            ComputedReason = "Floating-point overflow";
+            break;
+        case FPE_FLTUND:
+            ComputedReason = "Floating-point underflow";
+            break;
+        case FPE_FLTRES:
+            ComputedReason = "Floating-point inexact result";
+            break;
+        case FPE_FLTINV:
+            ComputedReason = "Invalid floating-point operation";
+            break;
+        case FPE_FLTSUB:
+            ComputedReason = "Subscript out of range";
+            break;
+        default:
+            ComputedReason = "Unknown SIGFPE";
+        }
+        (void)snprintf(ReasonBuf, ReasonSize, "%s at ip 0x%lx", ComputedReason,
+                (unsigned long)Buffer->context_info.si.si_addr);
+
+    }
+    else if (Buffer->context_info.si.si_signo == SIGINT)
+    {
+        /* interrupt e.g. CTRL+C */
+        (void)snprintf(ReasonBuf, ReasonSize, "Caught SIGINT");
+    }
+    else
+    {
+        /*
+         * other signal....
+         * POSIX 2008 does provide a strsignal() function to get the name, but this
+         * is a newer spec than what is targeted by CFE, so just print the number.
+         */
+        (void)snprintf(ReasonBuf, ReasonSize, "Caught Signal %d",Buffer->context_info.si.si_signo);
+    }
+
+    return CFE_PSP_SUCCESS;
+}
+
+

--- a/psp/fsw/arm-freertos/src/cfe_psp_memory.c
+++ b/psp/fsw/arm-freertos/src/cfe_psp_memory.c
@@ -1,0 +1,834 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+** File:  cfe_psp_memory.c
+**
+**      OSX x86 Linux Version
+**
+** Purpose:
+**   cFE PSP Memory related functions. This is the implementation of the cFE 
+**   memory areas that have to be preserved, and the API that is designed to allow
+**   acccess to them. It also contains memory related routines to return the
+**   address of the kernel code used in the cFE checksum.
+**
+** History:
+**   2006/09/29  A. Cudmore      | Initial version for OS X 
+**
+******************************************************************************/
+
+/*
+**  Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/ipc.h>
+#include <sys/shm.h>
+#include <fcntl.h>
+
+/*
+** cFE includes 
+*/
+#include "common_types.h"
+#include "osapi.h"
+
+/*
+** Types and prototypes for this module
+*/
+#include "cfe_psp.h"
+
+/*
+** PSP Specific defines
+*/
+#include "cfe_psp_config.h"
+#include "cfe_psp_memory.h"
+
+#define CFE_PSP_CDS_KEY_FILE ".cdskeyfile"
+#define CFE_PSP_RESET_KEY_FILE ".resetkeyfile"
+#define CFE_PSP_RESERVED_KEY_FILE ".reservedkeyfile"
+
+#include <target_config.h>
+
+/*
+ * Define the PSP-supported capacities to be the maximum allowed,
+ * (since the PC-linux PSP has the advantage of abundant disk space to hold this)
+ */
+#define CFE_PSP_CDS_SIZE            (GLOBAL_CONFIGDATA.CfeConfig->CdsSize)
+#define CFE_PSP_RESET_AREA_SIZE     (GLOBAL_CONFIGDATA.CfeConfig->ResetAreaSize)
+#define CFE_PSP_USER_RESERVED_SIZE  (GLOBAL_CONFIGDATA.CfeConfig->UserReservedSize)
+
+
+typedef struct
+{
+    CFE_PSP_ReservedMemoryBootRecord_t BootRecord;
+    CFE_PSP_ExceptionStorage_t ExceptionStorage;
+} CFE_PSP_LinuxReservedAreaFixedLayout_t;
+
+
+/*
+** Internal prototypes for this module
+*/
+void CFE_PSP_InitCDS(void);
+void CFE_PSP_InitResetArea(void);
+void CFE_PSP_InitVolatileDiskMem(void);
+void CFE_PSP_InitUserReservedArea(void);
+
+/*
+**  External Declarations
+*/
+extern unsigned int _init;
+extern unsigned int _fini;
+
+/*
+** Global variables
+*/
+int    ResetAreaShmId;
+int    CDSShmId;
+int    UserShmId;
+                                                                              
+/*
+** Pointer to the vxWorks USER_RESERVED_MEMORY area
+** The sizes of each memory area is defined in os_processor.h for this architecture.
+*/
+CFE_PSP_ReservedMemoryMap_t CFE_PSP_ReservedMemoryMap;
+
+                                                                              
+/*
+*********************************************************************************
+** CDS related functions
+*********************************************************************************
+*/
+/*
+**  
+*/
+/******************************************************************************
+**  Function: CFE_PSP_InitCDS
+**
+**  Purpose: This function is used by the ES startup code to initialize the 
+**            Critical Data store area
+**  
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+
+void CFE_PSP_InitCDS(void)
+{
+   key_t key;
+
+   /* 
+   ** Make the Shared memory key
+   */
+   if ((key = ftok(CFE_PSP_CDS_KEY_FILE, 'R')) == -1) 
+   {
+        OS_printf("CFE_PSP: Cannot Create CDS Shared memory key!\n");
+        exit(-1);
+   }
+
+   /* 
+   ** connect to (and possibly create) the segment: 
+   */
+   if ((CDSShmId = shmget(key, CFE_PSP_CDS_SIZE, 0644 | IPC_CREAT)) == -1) 
+   {
+        OS_printf("CFE_PSP: Cannot shmget CDS Shared memory Segment!\n");
+        exit(-1);
+   }
+
+   /* 
+   ** attach to the segment to get a pointer to it: 
+   */
+   CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr = shmat(CDSShmId, (void *)0, 0);
+   if (CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr == (void*)(-1))
+   {
+        OS_printf("CFE_PSP: Cannot shmat to CDS Shared memory Segment!\n");
+        exit(-1);
+   }
+
+   CFE_PSP_ReservedMemoryMap.CDSMemory.BlockSize = CFE_PSP_CDS_SIZE;
+}
+
+
+/******************************************************************************
+**  Function: CFE_PSP_DeleteCDS
+**
+**  Purpose:
+**   This is an internal function to delete the CDS Shared memory segment. 
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_DeleteCDS(void)
+{
+
+   int    ReturnCode;
+   struct shmid_ds ShmCtrl;
+   
+   ReturnCode = shmctl(CDSShmId, IPC_RMID, &ShmCtrl);
+   
+   if ( ReturnCode == 0 )
+   {
+       OS_printf("CFE_PSP: Critical Data Store Shared memory segment removed\n");
+   }
+   else
+   {
+       OS_printf("CFE_PSP: Error Removing Critical Data Store Shared memory Segment.\n");
+       OS_printf("CFE_PSP: It can be manually checked and removed using the ipcs and ipcrm commands.\n");
+   }
+
+
+}
+
+/******************************************************************************
+**  Function: CFE_PSP_GetCDSSize
+**
+**  Purpose: 
+**    This function fetches the size of the OS Critical Data Store area.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+
+int32 CFE_PSP_GetCDSSize(uint32 *SizeOfCDS)
+{
+   int32 return_code;
+   
+   if ( SizeOfCDS == NULL )
+   {
+       return_code = CFE_PSP_ERROR;
+   }
+   else
+   {
+       *SizeOfCDS = CFE_PSP_CDS_SIZE;
+       return_code = CFE_PSP_SUCCESS;
+   }
+   
+   return(return_code);
+}
+
+/******************************************************************************
+**  Function: CFE_PSP_WriteToCDS
+**
+**  Purpose:
+**    This function writes to the CDS Block.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+
+int32 CFE_PSP_WriteToCDS(const void *PtrToDataToWrite, uint32 CDSOffset, uint32 NumBytes)
+{
+   uint8 *CopyPtr;
+   int32  return_code;
+         
+   if ( PtrToDataToWrite == NULL )
+   {
+       return_code = CFE_PSP_ERROR;
+   }
+   else
+   {
+       if ( (CDSOffset < CFE_PSP_CDS_SIZE ) && ( (CDSOffset + NumBytes) <= CFE_PSP_CDS_SIZE ))
+       {
+           CopyPtr = CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr;
+           CopyPtr += CDSOffset;
+           memcpy(CopyPtr, (char *)PtrToDataToWrite,NumBytes);
+          
+           return_code = CFE_PSP_SUCCESS;
+       }
+       else
+       {
+          return_code = CFE_PSP_ERROR;
+       }
+       
+   } /* end if PtrToDataToWrite == NULL */
+   
+   return(return_code);
+}
+
+
+
+/******************************************************************************
+**  Function: CFE_PSP_ReadFromCDS
+**
+**  Purpose:
+**   This function reads from the CDS Block
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+
+int32 CFE_PSP_ReadFromCDS(void *PtrToDataToRead, uint32 CDSOffset, uint32 NumBytes)
+{
+   uint8 *CopyPtr;
+   int32  return_code;
+      
+   if ( PtrToDataToRead == NULL )
+   {
+       return_code = CFE_PSP_ERROR;
+   }
+   else
+   {
+       if ( (CDSOffset < CFE_PSP_CDS_SIZE ) && ( (CDSOffset + NumBytes) <= CFE_PSP_CDS_SIZE ))
+       {
+           CopyPtr = CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr;
+           CopyPtr += CDSOffset;
+           memcpy((char *)PtrToDataToRead,CopyPtr, NumBytes);
+          
+           return_code = CFE_PSP_SUCCESS;
+       }
+       else
+       {
+          return_code = CFE_PSP_ERROR;
+       }
+       
+   } /* end if PtrToDataToWrite == NULL */
+   
+   return(return_code);
+   
+}
+
+/*
+*********************************************************************************
+** ES Reset Area related functions
+*********************************************************************************
+*/
+
+/******************************************************************************
+**  Function: CFE_PSP_InitESResetArea
+**
+**  Purpose:
+**    This function is used by the ES startup code to initialize the
+**     ES Reset Area.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_InitResetArea(void)
+{
+
+   key_t key;
+   size_t total_size;
+   size_t reset_offset;
+   size_t align_mask;
+   cpuaddr block_addr;
+   CFE_PSP_LinuxReservedAreaFixedLayout_t *FixedBlocksPtr;
+   /* 
+   ** Make the Shared memory key
+   */
+   if ((key = ftok(CFE_PSP_RESET_KEY_FILE, 'R')) == -1) 
+   {
+        OS_printf("CFE_PSP: Cannot Create Reset Area Shared memory key!\n");
+        exit(-1);
+   }
+
+   /*
+    * NOTE: Historically the CFE ES reset area also contains the Exception log.
+    * This is now allocated as a separate structure in the PSP, but it can
+    * reside in this shared memory segment so it will be preserved on a processor
+    * reset.
+    */
+   align_mask = sysconf(_SC_PAGESIZE) - 1; /* align blocks to whole memory pages */
+   total_size = sizeof(CFE_PSP_LinuxReservedAreaFixedLayout_t);
+   total_size = (total_size + align_mask) & ~align_mask;
+   reset_offset = total_size;
+   total_size += CFE_PSP_RESET_AREA_SIZE;
+   total_size = (total_size + align_mask) & ~align_mask;
+
+   /* 
+   ** connect to (and possibly create) the segment: 
+   */
+   if ((ResetAreaShmId = shmget(key, total_size, 0644 | IPC_CREAT)) == -1)
+   {
+        OS_printf("CFE_PSP: Cannot shmget Reset Area Shared memory Segment!\n");
+        exit(-1);
+   }
+
+   /* 
+   ** attach to the segment to get a pointer to it: 
+   */
+   block_addr = (cpuaddr)shmat(ResetAreaShmId, (void *)0, 0);
+   if (block_addr == (cpuaddr)(-1))
+   {
+        OS_printf("CFE_PSP: Cannot shmat to Reset Area Shared memory Segment!\n");
+        exit(-1);
+   }
+
+   FixedBlocksPtr = (CFE_PSP_LinuxReservedAreaFixedLayout_t *)block_addr;
+   block_addr += reset_offset;
+
+   CFE_PSP_ReservedMemoryMap.BootPtr = &FixedBlocksPtr->BootRecord;
+   CFE_PSP_ReservedMemoryMap.ExceptionStoragePtr = &FixedBlocksPtr->ExceptionStorage;
+
+   CFE_PSP_ReservedMemoryMap.ResetMemory.BlockPtr = (void*)block_addr;
+   CFE_PSP_ReservedMemoryMap.ResetMemory.BlockSize = CFE_PSP_RESET_AREA_SIZE;
+}
+
+
+/******************************************************************************
+**  Function: CFE_PSP_DeleteResetArea
+**
+**  Purpose:
+**   This is an internal function to delete the Reset Area Shared memory segment. 
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_DeleteResetArea(void)
+{
+   int    ReturnCode;
+   struct shmid_ds ShmCtrl;
+   
+   ReturnCode = shmctl(ResetAreaShmId, IPC_RMID, &ShmCtrl);
+   
+   if ( ReturnCode == 0 )
+   {
+       OS_printf("Reset Area Shared memory segment removed\n");
+   }
+   else
+   {
+       OS_printf("Error Removing Reset Area Shared memory Segment.\n");
+       OS_printf("It can be manually checked and removed using the ipcs and ipcrm commands.\n");
+   }
+
+
+}
+
+
+/*
+*/
+/******************************************************************************
+**  Function: CFE_PSP_GetResetArea
+**
+**  Purpose:
+**     This function returns the location and size of the ES Reset information area. 
+**     This area is preserved during a processor reset and is used to store the 
+**     ER Log, System Log and reset related variables
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+int32 CFE_PSP_GetResetArea (cpuaddr *PtrToResetArea, uint32 *SizeOfResetArea)
+{
+   int32 return_code;
+   
+   if ( SizeOfResetArea == NULL )
+   {
+      return_code = CFE_PSP_ERROR;
+   }
+   else
+   {
+      *PtrToResetArea = (cpuaddr)CFE_PSP_ReservedMemoryMap.ResetMemory.BlockPtr;
+      *SizeOfResetArea = CFE_PSP_ReservedMemoryMap.ResetMemory.BlockSize;
+      return_code = CFE_PSP_SUCCESS;
+   }
+   
+   return(return_code);
+}
+
+/*
+*********************************************************************************
+** ES User Reserved Area related functions
+*********************************************************************************
+*/
+   
+/******************************************************************************
+**  Function: CFE_PSP_InitUserReservedArea 
+**
+**  Purpose:
+**    This function is used by the ES startup code to initialize the
+**      ES user reserved area.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_InitUserReservedArea(void)
+{
+   key_t key;
+
+   /* 
+   ** Make the Shared memory key
+   */
+   if ((key = ftok(CFE_PSP_RESERVED_KEY_FILE, 'R')) == -1) 
+   {
+        OS_printf("CFE_PSP: Cannot Create User Reserved Area Shared memory key!\n");
+        exit(-1);
+   }
+
+   /* 
+   ** connect to (and possibly create) the segment: 
+   */
+   if ((UserShmId = shmget(key, CFE_PSP_USER_RESERVED_SIZE, 0644 | IPC_CREAT)) == -1) 
+   {
+        OS_printf("CFE_PSP: Cannot shmget User Reserved Area Shared memory Segment!\n");
+        exit(-1);
+   }
+
+   /* 
+   ** attach to the segment to get a pointer to it: 
+   */
+   CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockPtr = shmat(UserShmId, (void *)0, 0);
+   if (CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockPtr == (void*)(-1))
+   {
+        OS_printf("CFE_PSP: Cannot shmat to User Reserved Area Shared memory Segment!\n");
+        exit(-1);
+   }
+
+   CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockSize = CFE_PSP_USER_RESERVED_SIZE;
+}
+
+/******************************************************************************
+**  Function: CFE_PSP_DeleteUserReservedArea
+**
+**  Purpose:
+**   This is an internal function to delete the User Reserved Shared memory segment. 
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_DeleteUserReservedArea(void)
+{
+   int    ReturnCode;
+   struct shmid_ds ShmCtrl;
+   
+   ReturnCode = shmctl(UserShmId, IPC_RMID, &ShmCtrl);
+   
+   if ( ReturnCode == 0 )
+   {
+       OS_printf("User Reserved Area Shared memory segment removed\n");
+   }
+   else
+   {
+       OS_printf("Error Removing User Reserved Area Shared memory Segment.\n");
+       OS_printf("It can be manually checked and removed using the ipcs and ipcrm commands.\n");
+   }
+}
+
+
+/******************************************************************************
+**  Function: CFE_PSP_GetUserReservedArea
+**
+**  Purpose:
+**    This function returns the location and size of the memory used for the cFE
+**     User reserved area.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+int32 CFE_PSP_GetUserReservedArea(cpuaddr *PtrToUserArea, uint32 *SizeOfUserArea )
+{
+   int32 return_code;
+   
+   if ( SizeOfUserArea == NULL )
+   {
+      return_code = CFE_PSP_ERROR;
+   }
+   else
+   {
+      *PtrToUserArea = (cpuaddr)CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockPtr;
+      *SizeOfUserArea = CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockSize;
+      return_code = CFE_PSP_SUCCESS;
+   }
+   
+   return(return_code);
+}
+
+/*
+*********************************************************************************
+** ES Volatile disk memory related functions
+*********************************************************************************
+*/
+
+/******************************************************************************
+**  Function: CFE_PSP_InitVolatileDiskMem
+**
+**  Purpose:
+**   This function is used by the ES startup code to initialize the memory
+**   used by the volatile disk. On a desktop/posix platform this is currently
+**   a no-op, because the volatile disk is being mapped to the desktop.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_InitVolatileDiskMem(void)
+{
+   /*
+   ** Here, we want to clear out the volatile ram disk contents
+   ** on a power on reset 
+   */
+}
+
+/******************************************************************************
+**  Function: CFE_PSP_GetVolatileDiskMem
+**
+**  Purpose:
+**    This function returns the location and size of the memory used for the cFE
+**     volatile disk.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+int32 CFE_PSP_GetVolatileDiskMem(cpuaddr *PtrToVolDisk, uint32 *SizeOfVolDisk )
+{
+   int32 return_code;
+   
+   if ( SizeOfVolDisk == NULL )
+   {
+      return_code = CFE_PSP_ERROR;
+   }
+   else
+   {
+      *PtrToVolDisk = (cpuaddr)CFE_PSP_ReservedMemoryMap.VolatileDiskMemory.BlockPtr;
+      *SizeOfVolDisk = CFE_PSP_ReservedMemoryMap.VolatileDiskMemory.BlockSize;
+      return_code = CFE_PSP_SUCCESS;
+   }
+   
+   return(return_code);
+
+}
+
+/*
+*********************************************************************************
+** ES BSP Top Level Reserved memory initialization
+*********************************************************************************
+*/
+
+/******************************************************************************
+**  Function: CFE_PSP_InitProcessorReservedMemory
+**
+**  Purpose:
+**    This function performs the top level reserved memory initialization.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_SetupReservedMemoryMap(void)
+{
+   int   tempFd;
+   
+   /*
+   ** Create the key files for the shared memory segments
+   ** The files are not needed, so they are closed right away.
+   */
+   tempFd = open(CFE_PSP_CDS_KEY_FILE, O_RDONLY | O_CREAT, S_IRWXU );
+   close(tempFd);
+   tempFd = open(CFE_PSP_RESET_KEY_FILE, O_RDONLY | O_CREAT, S_IRWXU );
+   close(tempFd);
+   tempFd = open(CFE_PSP_RESERVED_KEY_FILE, O_RDONLY | O_CREAT, S_IRWXU );
+   close(tempFd);
+
+   /*
+    * The setup of each section is done as a separate init.
+    *
+    * Any failures within these routines call exit(), so there
+    * is no need to check status - failure means no return.
+    */
+
+   CFE_PSP_InitCDS();
+   CFE_PSP_InitResetArea();
+   CFE_PSP_InitVolatileDiskMem();
+   CFE_PSP_InitUserReservedArea();
+}
+
+int32 CFE_PSP_InitProcessorReservedMemory( uint32 RestartType )
+{
+
+    /*
+     * Clear the segments only on a POWER ON reset
+     *
+     * Newly-created segments should already be zeroed out,
+     * but this ensures it.
+     */
+    if ( RestartType == CFE_PSP_RST_TYPE_POWERON )
+    {
+        OS_printf("CFE_PSP: Clearing out CFE CDS Shared memory segment.\n");
+        memset(CFE_PSP_ReservedMemoryMap.CDSMemory.BlockPtr, 0, CFE_PSP_CDS_SIZE);
+        OS_printf("CFE_PSP: Clearing out CFE Reset Shared memory segment.\n");
+        memset(CFE_PSP_ReservedMemoryMap.ResetMemory.BlockPtr, 0, CFE_PSP_RESET_AREA_SIZE);
+        OS_printf("CFE_PSP: Clearing out CFE User Reserved Shared memory segment.\n");
+        memset(CFE_PSP_ReservedMemoryMap.UserReservedMemory.BlockPtr, 0, CFE_PSP_USER_RESERVED_SIZE);
+
+        memset(CFE_PSP_ReservedMemoryMap.BootPtr, 0, sizeof(*CFE_PSP_ReservedMemoryMap.BootPtr));
+        memset(CFE_PSP_ReservedMemoryMap.ExceptionStoragePtr, 0, sizeof(*CFE_PSP_ReservedMemoryMap.ExceptionStoragePtr));
+
+        /*
+         * If an unclean shutdown occurs, try to do a PROCESSOR reset next.
+         * This will attempt to preserve the exception and reset log content.
+         */
+        CFE_PSP_ReservedMemoryMap.BootPtr->NextResetType = CFE_PSP_RST_TYPE_PROCESSOR;
+    }
+    else
+    {
+        /*
+         * If an unclean shutdown occurs after a PROCESSOR reset, then next time should
+         * be a POWERON reset.
+         */
+        CFE_PSP_ReservedMemoryMap.BootPtr->NextResetType = CFE_PSP_RST_TYPE_POWERON;
+    }
+
+    /*
+     * Reset the boot record validity flag (always).
+     *
+     * If an unclean shutdown occurs, such as a software crash or abort, this
+     * will remain in the shm structure and it can be detected at startup.
+     *
+     * This can be used to differentiate between an intentional and unintentional
+     * processor reset.
+     *
+     * If a directed shutdown occurs (via CFE_PSP_Restart) then this
+     * is overwritten with the valid value.
+     */
+    CFE_PSP_ReservedMemoryMap.BootPtr->ValidityFlag = CFE_PSP_BOOTRECORD_INVALID;
+
+
+    return(CFE_PSP_SUCCESS);
+}
+
+/******************************************************************************
+**  Function: CFE_PSP_DeleteProcessorReservedMemory
+**
+**  Purpose:
+**    This function cleans up all of the shared memory segments in the 
+**     Linux/OSX ports.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_DeleteProcessorReservedMemory(void)
+{
+   
+   CFE_PSP_DeleteCDS();
+   CFE_PSP_DeleteResetArea();
+   CFE_PSP_DeleteUserReservedArea();
+}
+   
+/*
+*********************************************************************************
+** ES BSP kernel memory segment functions
+*********************************************************************************
+*/
+
+/******************************************************************************
+**  Function: CFE_PSP_GetKernelTextSegmentInfo
+**
+**  Purpose:
+**    This function returns the start and end address of the kernel text segment.
+**     It may not be implemented on all architectures.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+int32 CFE_PSP_GetKernelTextSegmentInfo(cpuaddr *PtrToKernelSegment, uint32 *SizeOfKernelSegment)
+{
+   /*
+   ** Prevent warnings by referencing parameters
+   */
+   if ( PtrToKernelSegment == NULL || SizeOfKernelSegment == NULL )
+   {
+      return(CFE_PSP_ERROR);
+   }
+   
+   return(CFE_PSP_ERROR_NOT_IMPLEMENTED);
+   
+}
+
+
+/******************************************************************************
+**  Function: CFE_PSP_GetCFETextSegmentInfo
+**
+**  Purpose:
+**    This function returns the start and end address of the CFE text segment.
+**     It may not be implemented on all architectures.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+int32 CFE_PSP_GetCFETextSegmentInfo(cpuaddr *PtrToCFESegment, uint32 *SizeOfCFESegment)
+{
+   int32 return_code;
+   
+   if ( SizeOfCFESegment == NULL )
+   {
+      return_code = CFE_PSP_ERROR;
+   }
+   else
+   {
+      *PtrToCFESegment = (cpuaddr)(&_init);
+      *SizeOfCFESegment = (uint32) (((cpuaddr) &_fini) - ((cpuaddr) &_init));
+      
+      return_code = CFE_PSP_SUCCESS;
+   }
+   
+   return(return_code);
+}
+

--- a/psp/fsw/arm-freertos/src/cfe_psp_memtab.c
+++ b/psp/fsw/arm-freertos/src/cfe_psp_memtab.c
@@ -1,0 +1,59 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File   :	cfe_psp_memtab.c
+**
+** Author :     Alan Cudmore	
+**
+** Purpose:     Memory Range Table for cFE/PSP.
+**
+**
+*/
+
+/*
+** Includes
+*/
+
+#include "common_types.h"
+#include "osapi.h"
+#include "cfe_psp.h"
+#include "cfe_psp_config.h"
+
+
+
+/*
+** Valid memory map for this target.
+** If you need to add more entries, increase CFE_PSP_MEM_TABLE_SIZE in the osconfig.h file.
+*/
+CFE_PSP_MemTable_t CFE_PSP_MemoryTable[CFE_PSP_MEM_TABLE_SIZE] = 
+{
+   { CFE_PSP_MEM_RAM, CFE_PSP_MEM_SIZE_DWORD, 0, 0xFFFFFFFF, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+   { CFE_PSP_MEM_INVALID, 0, 0, 0, CFE_PSP_MEM_ATTR_READWRITE },
+};
+

--- a/psp/fsw/arm-freertos/src/cfe_psp_ssr.c
+++ b/psp/fsw/arm-freertos/src/cfe_psp_ssr.c
@@ -1,0 +1,75 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+** File:  cfe_psp_ssr.c
+**
+** Purpose:
+**   This file contains glue routines between the cFE and the OS Board Support Package ( BSP ).
+**   The functions here allow the cFE to interface functions that are board and OS specific
+**   and usually dont fit well in the OS abstraction layer.
+**
+** History:
+**   2005/06/05  Alan Cudmore    | Initial version,
+**
+******************************************************************************/
+
+/*
+** cFE includes
+*/
+#include "common_types.h"
+#include "osapi.h"
+
+/*
+** Types and prototypes for this module
+*/
+#include "cfe_psp.h"
+#include "cfe_psp_config.h"
+
+/*
+**  Standard Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+/******************************************************************************
+**  Function:  CFE_PSP_InitSSR
+**
+**  Purpose:
+**    Initializes the Solid State Recorder device. This can be filled in for the platform.
+**
+**  Arguments:
+**    bus, device, device name
+**
+**  Return:
+**    (none)
+*/
+
+int32 CFE_PSP_InitSSR(uint32 bus, uint32 device, char *DeviceName )
+{
+   int32 Status;
+
+   Status = CFE_PSP_ERROR;
+   
+   return(Status);
+
+}
+

--- a/psp/fsw/arm-freertos/src/cfe_psp_start.c
+++ b/psp/fsw/arm-freertos/src/cfe_psp_start.c
@@ -1,0 +1,659 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+** File:  cfe_psp_start.c
+**
+** Purpose:
+**   cFE BSP main entry point.
+**
+** History:
+**   2005/07/26  A. Cudmore      | Initial version for OS X/Linux 
+**
+******************************************************************************/
+
+/*
+**  Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <signal.h>
+#include <sys/time.h>
+#include <getopt.h>
+#include <string.h>
+#include <limits.h>
+#include <pthread.h>
+#include <sched.h>
+#include <errno.h>
+
+/*
+** cFE includes 
+*/
+#include "common_types.h"
+#include "osapi.h"
+
+#include "cfe_psp.h"
+#include "cfe_psp_memory.h"
+
+/*
+ * The preferred way to obtain the CFE tunable values at runtime is via
+ * the dynamically generated configuration object.  This allows a single build
+ * of the PSP to be completely CFE-independent.
+ */
+#include <target_config.h>
+#include "cfe_psp_module.h"
+
+#define CFE_PSP_MAIN_FUNCTION        (*GLOBAL_CONFIGDATA.CfeConfig->SystemMain)
+#define CFE_PSP_1HZ_FUNCTION         (*GLOBAL_CONFIGDATA.CfeConfig->System1HzISR)
+#define CFE_PSP_NONVOL_STARTUP_FILE  (GLOBAL_CONFIGDATA.CfeConfig->NonvolStartupFile)
+#define CFE_PSP_CPU_ID               (GLOBAL_CONFIGDATA.Default_CpuId)
+#define CFE_PSP_CPU_NAME             (GLOBAL_CONFIGDATA.Default_CpuName)
+#define CFE_PSP_SPACECRAFT_ID        (GLOBAL_CONFIGDATA.Default_SpacecraftId)
+
+/*
+** Defines
+*/
+
+#define CFE_PSP_CPU_NAME_LENGTH  32
+#define CFE_PSP_RESET_NAME_LENGTH 10
+
+/*
+** Typedefs for this module
+*/
+
+/*
+** Structure for the Command line parameters
+*/
+typedef struct
+{   
+   char     ResetType[CFE_PSP_RESET_NAME_LENGTH];   /* Reset type can be "PO" for Power on or "PR" for Processor Reset */
+   uint32   GotResetType;    /* did we get the ResetType parameter ? */
+
+   uint32   SubType;         /* Reset Sub Type ( 1 - 5 )  */
+   uint32   GotSubType;      /* did we get the ResetSubType parameter ? */
+   
+   char     CpuName[CFE_PSP_CPU_NAME_LENGTH];     /* CPU Name */
+   uint32   GotCpuName;      /* Did we get a CPU Name ? */
+
+   uint32   CpuId;            /* CPU ID */
+   uint32   GotCpuId;         /* Did we get a CPU Id ?*/
+
+   uint32   SpacecraftId;     /* Spacecraft ID */ 
+   uint32   GotSpacecraftId;  /* Did we get a Spacecraft ID */
+   
+} CFE_PSP_CommandData_t;
+
+/*
+** Prototypes for this module
+*/
+void CFE_PSP_TimerHandler (int signum);
+void CFE_PSP_DisplayUsage(char *Name );
+void CFE_PSP_ProcessArgumentDefaults(CFE_PSP_CommandData_t *CommandDataDefault);
+void CFE_PSP_SetupLocal1Hz(void);
+
+/*
+** Global variables
+*/
+uint32              TimerCounter;
+CFE_PSP_CommandData_t CommandData;
+uint32              CFE_PSP_SpacecraftId;
+uint32              CFE_PSP_CpuId;
+char                CFE_PSP_CpuName[CFE_PSP_CPU_NAME_LENGTH];
+
+CFE_PSP_IdleTaskState_t  CFE_PSP_IdleTaskState;
+
+/*
+** getopts parameter passing options string
+*/
+static const char *optString = "R:S:C:I:N:h";
+
+/*
+** getopts_long long form argument table
+*/
+static const struct option longOpts[] = {
+   { "reset",     required_argument, NULL, 'R' },
+   { "subtype",   required_argument, NULL, 'S' },
+   { "cpuid",     required_argument, NULL, 'C' },
+   { "scid",      required_argument, NULL, 'I'},
+   { "cpuname",   required_argument, NULL, 'N'},
+   { "help",      no_argument,       NULL, 'h' },
+   { NULL,        no_argument,       NULL,  0 }
+};
+
+
+/******************************************************************************
+**  Function:  main()
+**
+**  Purpose:
+**    BSP Application entry point.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void OS_Application_Startup(void)
+{
+   uint32             reset_type;
+   uint32             reset_subtype;
+   int32              time_status;
+   uint32             sys_timebase_id;
+   uint32             fs_id;
+   int                opt = 0;
+   int                longIndex = 0;
+   int32              Status;
+   char * const *     argv;
+   int                argc;
+
+   /*
+   ** Initialize the CommandData struct 
+   */
+   memset(&(CommandData), 0, sizeof(CFE_PSP_CommandData_t));
+
+   /* 
+   ** Process the arguments with getopt_long(), then 
+   ** start the cFE
+   */
+   argc = OS_BSP_GetArgC();
+   argv = OS_BSP_GetArgV();
+   opt = getopt_long( argc, argv, optString, longOpts, &longIndex );
+   while( opt != -1 ) 
+   {
+      switch( opt ) 
+      {
+         case 'R':
+            strncpy(CommandData.ResetType, optarg, CFE_PSP_RESET_NAME_LENGTH-1);
+            CommandData.ResetType[CFE_PSP_RESET_NAME_LENGTH-1] = 0;
+
+            if ((strncmp(CommandData.ResetType, "PO", CFE_PSP_RESET_NAME_LENGTH ) != 0 ) &&
+                (strncmp(CommandData.ResetType, "PR", CFE_PSP_RESET_NAME_LENGTH ) != 0 ))
+            {
+               printf("\nERROR: Invalid Reset Type: %s\n\n",CommandData.ResetType);
+               CommandData.GotResetType = 0;
+               CFE_PSP_DisplayUsage(argv[0]);
+               break;
+            }
+            printf("CFE_PSP: Reset Type: %s\n",(char *)optarg);
+            CommandData.GotResetType = 1;
+            break;
+				
+         case 'S':
+            CommandData.SubType = strtol(optarg, NULL, 0 );
+            if ( CommandData.SubType < 1 || CommandData.SubType > 5 )
+            {
+               printf("\nERROR: Invalid Reset SubType: %s\n\n",optarg);
+               CommandData.SubType = 0;
+               CommandData.GotSubType = 0;
+               CFE_PSP_DisplayUsage(argv[0]);
+               break;
+            }
+            printf("CFE_PSP: Reset SubType: %d\n",(int)CommandData.SubType);
+            CommandData.GotSubType = 1;
+            break;
+
+         case 'N':
+            strncpy(CommandData.CpuName, optarg, CFE_PSP_CPU_NAME_LENGTH-1 );
+            CommandData.CpuName[CFE_PSP_CPU_NAME_LENGTH-1] = 0;
+            printf("CFE_PSP: CPU Name: %s\n",CommandData.CpuName);
+            CommandData.GotCpuName = 1;
+            break;
+
+         case 'C':
+            CommandData.CpuId = strtol(optarg, NULL, 0 );
+            printf("CFE_PSP: CPU ID: %d\n",(int)CommandData.CpuId);
+            CommandData.GotCpuId = 1;
+            break;
+
+         case 'I':
+            CommandData.SpacecraftId = strtol(optarg, NULL, 0 );
+            printf("CFE_PSP: Spacecraft ID: %d\n",(int)CommandData.SpacecraftId);
+            CommandData.GotSpacecraftId = 1;
+            break;
+
+         case 'h':
+            CFE_PSP_DisplayUsage(argv[0]);
+            break;
+	
+         default:
+            CFE_PSP_DisplayUsage(argv[0]);
+            break;
+       }
+		
+       opt = getopt_long( argc, argv, optString, longOpts, &longIndex );
+   } /* end while */
+   
+   /*
+   ** Set the defaults for values that were not given for the 
+   ** optional arguments, and check for arguments that are required.
+   */
+   CFE_PSP_ProcessArgumentDefaults(&CommandData);
+
+   /*
+   ** Assign the Spacecraft ID, CPU ID, and CPU Name
+   */
+   CFE_PSP_SpacecraftId = CommandData.SpacecraftId;
+   CFE_PSP_CpuId = CommandData.CpuId;
+   strncpy(CFE_PSP_CpuName, CommandData.CpuName, sizeof(CFE_PSP_CpuName)-1);
+   CFE_PSP_CpuName[sizeof(CFE_PSP_CpuName)-1] = 0;
+
+   /*
+   ** Set the reset subtype
+   */
+   reset_subtype = CommandData.SubType;
+
+
+   /*
+   ** Initialize the OS API data structures
+   */
+   Status = OS_API_Init();
+   if (Status != OS_SUCCESS)
+   {
+       /* irrecoverable error if OS_API_Init() fails. */
+       /* note: use printf here, as OS_printf may not work */
+       printf("CFE_PSP: OS_API_Init() failure\n");
+       CFE_PSP_Panic(Status);
+   }
+
+   /*
+    * Map the PSP shared memory segments
+    */
+   CFE_PSP_SetupReservedMemoryMap();
+
+   /*
+    * Prepare for exception handling in the idle task
+    */
+   memset(&CFE_PSP_IdleTaskState, 0, sizeof(CFE_PSP_IdleTaskState));
+   CFE_PSP_IdleTaskState.ThreadID = pthread_self();
+
+   /*
+   ** Set up the timebase, if OSAL supports it
+   ** Done here so that the modules can also use it, if desired
+   **
+   ** This is a clock named "cFS-Master" that will serve to drive
+   ** all time-related CFE functions including the 1Hz signal.
+   **
+   ** Note the timebase is only prepared here; the application is
+   ** not ready to receive a callback yet, as it hasn't been started.
+   ** CFE TIME registers its own callback when it is ready to do so.
+   */
+   time_status = OS_TimeBaseCreate(&sys_timebase_id, "cFS-Master", NULL);
+   if (time_status == OS_SUCCESS)
+   {
+       /*
+        * Set the clock to trigger with 50ms resolution - slow enough that
+        * it will not hog CPU resources but fast enough to have sufficient resolution
+        * for most general timing purposes.
+        * (It may be better to move this to the mission config file)
+        */
+       time_status = OS_TimeBaseSet(sys_timebase_id, 50000, 50000);
+   }
+   else
+   {
+       /*
+        * Cannot create a timebase in OSAL.
+        *
+        * Note: Most likely this is due to building with
+        * the old/classic POSIX OSAL which does not support this.
+        *
+        * See below for workaround.
+        */
+       sys_timebase_id = 0;
+   }
+
+   /*
+   ** Set up the virtual FS mapping for the "/cf" directory
+   ** On this platform it is just a local/relative dir of the same name.
+   */
+   Status = OS_FileSysAddFixedMap(&fs_id, "./cf", "/cf");
+   if (Status != OS_SUCCESS)
+   {
+       /* Print for informational purposes --
+        * startup can continue, but loads may fail later, depending on config. */
+       OS_printf("CFE_PSP: OS_FileSysAddFixedMap() failure: %d\n", (int)Status);
+   }
+
+   /*
+   ** Initialize the statically linked modules (if any)
+   ** This is only applicable to CMake build - classic build
+   ** does not have the logic to selectively include/exclude modules
+   */
+   CFE_PSP_ModuleInit();
+     
+   sleep(1);
+
+   /*
+    * For informational purposes, show the state of the last exit
+    */
+   if (CFE_PSP_ReservedMemoryMap.BootPtr->ValidityFlag == CFE_PSP_BOOTRECORD_VALID)
+   {
+       OS_printf("CFE_PSP: Normal exit from previous cFE instance\n");
+   }
+   else if (CFE_PSP_ReservedMemoryMap.BootPtr->ValidityFlag == CFE_PSP_BOOTRECORD_INVALID)
+   {
+       OS_printf("CFE_PSP: Abnormal exit from previous cFE instance\n");
+   }
+
+   /*
+    * determine reset type...
+    * If not specified at the command line, then check the "boot record"
+    */
+   reset_type = 0;
+   if (!CommandData.GotResetType)
+   {
+       if (CFE_PSP_ReservedMemoryMap.BootPtr->ValidityFlag == CFE_PSP_BOOTRECORD_VALID ||
+               CFE_PSP_ReservedMemoryMap.BootPtr->ValidityFlag == CFE_PSP_BOOTRECORD_INVALID)
+       {
+           reset_type = CFE_PSP_ReservedMemoryMap.BootPtr->NextResetType;
+       }
+   }
+   else if (strncmp("PR", CommandData.ResetType, 2 ) == 0 )
+   {
+       reset_type = CFE_PSP_RST_TYPE_PROCESSOR;
+   }
+
+   if (reset_type == CFE_PSP_RST_TYPE_PROCESSOR)
+   {
+       OS_printf("CFE_PSP: Starting the cFE with a PROCESSOR reset.\n");
+   }
+   else
+   {
+       /* catch-all for anything else */
+       reset_type = CFE_PSP_RST_TYPE_POWERON;
+       OS_printf("CFE_PSP: Starting the cFE with a POWER ON reset.\n");
+   }
+
+
+   /*
+   ** Initialize the reserved memory 
+   */
+   Status = CFE_PSP_InitProcessorReservedMemory(reset_type);
+   if (Status != CFE_PSP_SUCCESS)
+   {
+       OS_printf("CFE_PSP: CFE_PSP_InitProcessorReservedMemory() Failure");
+       CFE_PSP_Panic(Status);
+   }
+
+   /*
+   ** Call cFE entry point.
+   */
+   CFE_PSP_MAIN_FUNCTION(reset_type, reset_subtype, 1, CFE_PSP_NONVOL_STARTUP_FILE);
+
+   /*
+    * Backward compatibility for old OSAL.
+    */
+   if (sys_timebase_id == 0 || time_status != OS_SUCCESS)
+   {
+       OS_printf("CFE_PSP: WARNING - Compatibility mode - using local 1Hz Interrupt\n");
+       CFE_PSP_SetupLocal1Hz();
+   }
+
+}
+
+void OS_Application_Run(void)
+{
+    int sig;
+    int ret;
+    sigset_t sigset;
+
+
+    /*
+     * Now that all main tasks are created,
+     * this original thread will exist just to service signals
+     * that aren't directed to a specific task.
+     *
+     * OSAL sets a very conservative signal mask that
+     * blocks most signals. Start by unblocking the
+     * ones that should be handled.
+     *
+     * Unblock SIGQUIT so the user can force exit the CFE
+     * by pressing CTRL+\ (default handler).  Also allow
+     * SIGTERM for which a handler was installed in CFE_PSP_AttachExceptions()
+     */
+    sigemptyset(&sigset);
+    sigaddset(&sigset, SIGQUIT);
+    sigaddset(&sigset, SIGTERM);
+    pthread_sigmask(SIG_UNBLOCK, &sigset, NULL);
+
+    /*
+     * Reset to the signal for background events (SIGUSR1)
+     */
+    sigemptyset(&sigset);
+    sigaddset(&sigset, CFE_PSP_EXCEPTION_EVENT_SIGNAL);
+
+    /*
+    ** just wait for events to occur and notify CFE
+    **
+    ** "shutdownreq" will become true if CFE calls CFE_PSP_Restart(),
+    ** indicating a request to gracefully exit and restart CFE.
+    */
+    while (!CFE_PSP_IdleTaskState.ShutdownReq)
+    {
+        /* go idle and wait for an event */
+        ret = sigwait(&sigset, &sig);
+
+        if (ret == 0 && !CFE_PSP_IdleTaskState.ShutdownReq &&
+                sig == CFE_PSP_EXCEPTION_EVENT_SIGNAL &&
+                GLOBAL_CFE_CONFIGDATA.SystemNotify != NULL)
+        {
+            /* notify the CFE of the event */
+            GLOBAL_CFE_CONFIGDATA.SystemNotify();
+        }
+    }
+
+   /*
+    * This happens if an unhandled exception occurs, or if the user presses CTRL+C
+    */
+   OS_printf("\nCFE_PSP: Shutdown initiated - Exiting cFE\n");
+   OS_TaskDelay(100);
+
+   OS_DeleteAllObjects();
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_TimerHandler()
+**
+**  Purpose:
+**    1hz "isr" routine for linux/OSX
+**    This timer handler will execute 4 times a second.
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_TimerHandler (int signum)
+{
+      /*
+      ** call the CFE_TIME 1hz ISR
+      */
+      if((TimerCounter % 4) == 0) CFE_PSP_1HZ_FUNCTION();
+
+	  /* update timer counter */
+	  TimerCounter++;
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_DisplayUsage
+**
+**  Purpose:
+**    Display program usage, and exit.
+**
+**  Arguments:
+**    Name -- the name of the binary.
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_DisplayUsage(char *Name )
+{
+
+   printf("usage : %s [-R <value>] [-S <value>] [-C <value] [-N <value] [-I <value] [-h] \n", Name);
+   printf("\n");
+   printf("        All parameters are optional and can be used in any order\n");
+   printf("\n");
+   printf("        Parameters include:\n");
+   printf("        -R [ --reset ] Reset Type is one of:\n");
+   printf("             PO   for Power On reset ( default )\n");
+   printf("             PR   for Processor Reset\n");
+   printf("        -S [ --subtype ] Reset Sub Type is one of\n");
+   printf("             1   for  Power on ( default )\n");
+   printf("             2   for  Push Button Reset\n");
+   printf("             3   for  Hardware Special Command Reset\n");
+   printf("             4   for  Watchdog Reset\n");
+   printf("             5   for  Reset Command\n");
+   printf("        -C [ --cpuid ]   CPU ID is an integer CPU identifier.\n");
+   printf("             The default  CPU ID is from the platform configuration file: %d\n",CFE_PSP_CPU_ID);
+   printf("        -N [ --cpuname ] CPU Name is a string to identify the CPU.\n");
+   printf("             The default  CPU Name is from the platform configuration file: %s\n",CFE_PSP_CPU_NAME);
+   printf("        -I [ --scid ]    Spacecraft ID is an integer Spacecraft identifier.\n");
+   printf("             The default Spacecraft ID is from the mission configuration file: %d\n",CFE_PSP_SPACECRAFT_ID);
+   printf("        -h [ --help ]    This message.\n");
+   printf("\n");
+   printf("       Example invocation:\n");
+   printf(" \n");
+   printf("       Short form:\n");
+   printf("       %s -R PO -S 1 -C 1 -N CPU1 -I 32\n",Name);
+   printf("       Long form:\n");
+   printf("       %s --reset PO --subtype 1 --cpuid 1 --cpuname CPU1 --scid 32\n",Name);
+   printf(" \n");
+
+   exit( 1 );
+}
+/******************************************************************************
+**  Function: CFE_PSP_ProcessArgumentDefaults
+**
+**  Purpose:
+**    This function assigns defaults to parameters and checks to make sure
+**    the user entered required parameters 
+**
+**  Arguments:
+**    CFE_PSP_CommandData_t *CommandDataDefault -- A pointer to the command parameters.
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_ProcessArgumentDefaults(CFE_PSP_CommandData_t *CommandDataDefault)
+{
+   if ( CommandDataDefault->GotSubType == 0 )
+   {
+      CommandDataDefault->SubType = 1;
+      printf("CFE_PSP: Default Reset SubType = 1\n");
+      CommandDataDefault->GotSubType = 1;
+   }
+   
+   if ( CommandDataDefault->GotCpuId == 0 )
+   {
+      CommandDataDefault->CpuId = CFE_PSP_CPU_ID;
+      printf("CFE_PSP: Default CPU ID = %d\n",CFE_PSP_CPU_ID);
+      CommandDataDefault->GotCpuId = 1;
+   }
+   
+   if ( CommandDataDefault->GotSpacecraftId == 0 )
+   {
+      CommandDataDefault->SpacecraftId = CFE_PSP_SPACECRAFT_ID;
+      printf("CFE_PSP: Default Spacecraft ID = %d\n",CFE_PSP_SPACECRAFT_ID);
+      CommandDataDefault->GotSpacecraftId = 1;
+   }
+   
+   if ( CommandDataDefault->GotCpuName == 0 )
+   {
+      strncpy(CommandDataDefault->CpuName, CFE_PSP_CPU_NAME, CFE_PSP_CPU_NAME_LENGTH-1 );
+      CommandDataDefault->CpuName[CFE_PSP_CPU_NAME_LENGTH-1] = 0;
+      printf("CFE_PSP: Default CPU Name: %s\n",CFE_PSP_CPU_NAME);
+      CommandDataDefault->GotCpuName = 1;
+   }
+
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_SetupLocal1Hz
+**
+**  Purpose:
+**    This is a backward-compatible timer setup that is invoked when
+**    there is a failure to set up the timebase in OSAL.  It is basically
+**    the old way of doing things.
+**
+**    IMPORTANT: Note this is technically incorrect as it gives the
+**    callback directly in the context of the signal handler.  It is
+**    against spec to use most OSAL functions within a signal.
+**
+**    This is included merely to mimic the previous system behavior. It
+**    should be removed in a future version of the PSP.
+**
+**
+**  Arguments:
+**    (none)
+**
+**  Return:
+**    (none)
+**
+*/
+
+void CFE_PSP_SetupLocal1Hz(void)
+{
+    struct sigaction    sa;
+    struct itimerval    timer;
+    int ret;
+
+    /*
+    ** Init timer counter
+    */
+    TimerCounter = 0;
+
+    /*
+    ** Install timer_handler as the signal handler for SIGALRM.
+    */
+    memset (&sa, 0, sizeof (sa));
+    sa.sa_handler = &CFE_PSP_TimerHandler;
+
+    /*
+    ** Configure the timer to expire after 250ms
+    **
+    ** (this is historical; the actual callback is invoked
+    ** only on every 4th timer tick.  previous versions of the
+    ** PSP did it this way, so this is preserved here).
+    */
+    timer.it_value.tv_sec  = 0;
+    timer.it_value.tv_usec = 250000;
+    timer.it_interval.tv_sec  = 0;
+    timer.it_interval.tv_usec = 250000;
+
+    ret = sigaction (SIGALRM, &sa, NULL);
+
+    if (ret < 0)
+    {
+        OS_printf("CFE_PSP: sigaction() error %d: %s \n", ret, strerror(errno));
+    }
+    else
+    {
+        ret = setitimer (ITIMER_REAL, &timer, NULL);
+        if (ret < 0)
+        {
+            OS_printf("CFE_PSP: setitimer() error %d: %s \n", ret, strerror(errno));
+        }
+    }
+}
+

--- a/psp/fsw/arm-freertos/src/cfe_psp_support.c
+++ b/psp/fsw/arm-freertos/src/cfe_psp_support.c
@@ -1,0 +1,202 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+** File:  cfe_psp_support.c
+**
+** Purpose:
+**   This file contains glue routines between the cFE and the OS Board Support Package ( BSP ).
+**   The functions here allow the cFE to interface functions that are board and OS specific
+**   and usually dont fit well in the OS abstraction layer.
+**
+******************************************************************************/
+
+/*
+**  Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "common_types.h"
+#include "osapi.h"
+
+/*
+** Types and prototypes for this module
+*/
+#include "cfe_psp.h"
+#include "cfe_psp_config.h"
+#include "cfe_psp_memory.h"
+
+
+/*
+** External Variables
+*/
+extern uint32  CFE_PSP_SpacecraftId;
+extern uint32  CFE_PSP_CpuId;
+
+
+/******************************************************************************
+**  Function:  CFE_PSP_Restart()
+**
+**  Purpose:
+**    Provides a common interface to the processor reset.
+**
+**  Arguments:
+**    reset_type  : Type of reset.
+**
+**  Return:
+**    (none)
+*/
+
+void CFE_PSP_Restart(uint32 reset_type)
+{
+   if ( reset_type == CFE_PSP_RST_TYPE_POWERON )
+   {
+       OS_printf("CFE_PSP: Exiting cFE with POWERON Reset status.\n");
+
+       /* Also delete the SHM segments, so they will be recreated on next boot */
+       /* Deleting these memories will unlink them, but active references should still work */
+       CFE_PSP_DeleteProcessorReservedMemory();
+   }
+   else
+   {
+       OS_printf("CFE_PSP: Exiting cFE with PROCESSOR Reset status.\n");
+   }
+
+   /*
+    * Record the reset type for the next boot.
+    */
+   CFE_PSP_ReservedMemoryMap.BootPtr->NextResetType = reset_type;
+   CFE_PSP_ReservedMemoryMap.BootPtr->ValidityFlag = CFE_PSP_BOOTRECORD_VALID;
+
+   /*
+    * Begin process of orderly shutdown.
+    *
+    * This should cause the original thread (main task) to wake up
+    * and start the shutdown procedure.
+    */
+   CFE_PSP_IdleTaskState.ShutdownReq = true;
+   pthread_kill(CFE_PSP_IdleTaskState.ThreadID, CFE_PSP_EXCEPTION_EVENT_SIGNAL);
+
+   /*
+    * Give time for the orderly shutdown to occur.
+    *
+    * Normally during shutdown this task will be deleted, and therefore
+    * this does not return.
+    *
+    * However, if problems occur (e.g. deadlock) eventually this timeout
+    * will expire and return.
+    */
+   OS_TaskDelay(CFE_PSP_RESTART_DELAY);
+
+   /*
+    * Timeout expired without this task being deleted, so abort().
+    *
+    * This should generate a core file to reveal what went wrong
+    * with normal shutdown.
+    */
+   abort();
+
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_Panic()
+**
+**  Purpose:
+**    Provides a common interface to abort the cFE startup process and return
+**    back to the OS.
+**
+**  Arguments:
+**    ErrorCode  : Reason for Exiting.
+**
+**  Return:
+**    (none)
+*/
+
+void CFE_PSP_Panic(int32 ErrorCode)
+{
+   OS_printf("CFE_PSP_Panic Called with error code = 0x%08X. Exiting.\n",(unsigned int)ErrorCode);
+   OS_printf("The cFE could not start.\n");
+   abort(); /* abort() is preferable to exit(-1), as it may create a core file for debug */
+}
+
+
+/******************************************************************************
+**  Function:  CFE_PSP_FlushCaches)
+**
+**  Purpose:
+**    Provides a common interface to flush the processor caches. This routine
+**    is in the BSP because it is sometimes implemented in hardware and
+**    sometimes taken care of by the RTOS.
+**
+**  Arguments:
+**
+**  Return:
+**    (none)
+*/
+void CFE_PSP_FlushCaches(uint32 type, void* address, uint32 size)
+{
+   printf("CFE_PSP_FlushCaches called -- Currently no Linux/OSX/Cygwin implementation\n");
+}
+
+/*
+** Name: CFE_PSP_GetProcessorId
+**
+** Purpose:
+**         return the processor ID.
+**
+**
+** Parameters:
+**
+** Global Inputs: None
+**
+** Global Outputs: None
+**
+**
+**
+** Return Values: Processor ID
+*/
+uint32 CFE_PSP_GetProcessorId    (void)
+{
+    return(CFE_PSP_CpuId);
+}
+
+
+/*
+** Name: CFE_PSP_GetSpacecraftId
+**
+** Purpose:
+**         return the spacecraft ID.
+**
+** Parameters:
+**
+** Global Inputs: None
+**
+** Global Outputs: None
+**
+**
+** Return Values: Spacecraft ID
+*/
+uint32 CFE_PSP_GetSpacecraftId   (void)
+{
+   return(CFE_PSP_SpacecraftId);
+}

--- a/psp/fsw/arm-freertos/src/cfe_psp_timer.c
+++ b/psp/fsw/arm-freertos/src/cfe_psp_timer.c
@@ -1,0 +1,190 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/************************************************************************************************
+** File:  cfe_psp_timer.c
+**
+** Purpose:
+**   This file contains glue routines between the cFE and the OS Board Support Package ( BSP ).
+**   The functions here allow the cFE to interface functions that are board and OS specific
+**   and usually dont fit well in the OS abstraction layer.
+**
+** History:
+**   2005/06/05  K.Audra    | Initial version,
+**
+*************************************************************************************************/
+
+/*
+**  Include Files
+*/
+
+
+/*
+** cFE includes
+*/
+#include "common_types.h"
+#include "osapi.h"
+
+/*
+**  System Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+** Types and prototypes for this module
+*/
+#include "cfe_psp.h"
+
+
+/******************* Macro Definitions ***********************/
+
+#define CFE_PSP_TIMER_TICKS_PER_SECOND       1000000     /* Resolution of the least significant 32 bits of the 64 bit
+                                                           time stamp returned by OS_BSPGet_Timebase in timer ticks per second.
+                                                           The timer resolution for accuracy should not be any slower than 1000000
+                                                           ticks per second or 1 us per tick */
+#define CFE_PSP_TIMER_LOW32_ROLLOVER         1000000     /* The number that the least significant 32 bits of the 64 bit
+                                                           time stamp returned by OS_BSPGet_Timebase rolls over.  If the lower 32
+                                                           bits rolls at 1 second, then the OS_BSP_TIMER_LOW32_ROLLOVER will be 1000000.
+                                                           if the lower 32 bits rolls at its maximum value (2^32) then
+                                                           OS_BSP_TIMER_LOW32_ROLLOVER will be 0. */
+
+/******************************************************************************
+**  Function:  CFE_PSP_GetTime()
+**
+**  Purpose: Gets the value of the time from the hardware
+**
+**  Arguments: LocalTime - where the time is returned through
+******************************************************************************/
+
+void CFE_PSP_GetTime( OS_time_t *LocalTime)
+{
+
+    /* since we don't have a hardware register to access like the mcp750,
+     * we use a call to the OS to get the time */
+
+    OS_GetLocalTime(LocalTime);
+
+}/* end CFE_PSP_GetLocalTime */
+
+
+
+/******************************************************************************
+**  Function:  CFE_PSP_Get_Timer_Tick()
+**
+**  Purpose:
+**    Provides a common interface to system clock tick. This routine
+**    is in the BSP because it is sometimes implemented in hardware and
+**    sometimes taken care of by the RTOS.
+**
+**  Arguments:
+**
+**  Return:
+**  OS system clock ticks per second
+*/
+uint32 CFE_PSP_Get_Timer_Tick(void)
+{
+   /* SUB -add function call code*/
+   return (0);
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_GetTimerTicksPerSecond()
+**
+**  Purpose:
+**    Provides the resolution of the least significant 32 bits of the 64 bit
+**    time stamp returned by OS_BSPGet_Timebase in timer ticks per second.
+**    The timer resolution for accuracy should not be any slower than 1000000
+**    ticks per second or 1 us per tick
+**
+**  Arguments:
+**
+**  Return:
+**    The number of timer ticks per second of the time stamp returned
+**    by CFE_PSP_Get_Timebase
+*/
+uint32 CFE_PSP_GetTimerTicksPerSecond(void)
+{
+    return(CFE_PSP_TIMER_TICKS_PER_SECOND);
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_GetTimerLow32Rollover()
+**
+**  Purpose:
+**    Provides the number that the least significant 32 bits of the 64 bit
+**    time stamp returned by CFE_PSP_Get_Timebase rolls over.  If the lower 32
+**    bits rolls at 1 second, then the CFE_PSP_TIMER_LOW32_ROLLOVER will be 1000000.
+**    if the lower 32 bits rolls at its maximum value (2^32) then
+**    CFE_PSP_TIMER_LOW32_ROLLOVER will be 0.
+**
+**  Arguments:
+**
+**  Return:
+**    The number that the least significant 32 bits of the 64 bit time stamp
+**    returned by CFE_PSP_Get_Timebase rolls over.
+*/
+uint32 CFE_PSP_GetTimerLow32Rollover(void)
+{
+    return(CFE_PSP_TIMER_LOW32_ROLLOVER);
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_Get_Timebase()
+**
+**  Purpose:
+**    Provides a common interface to system timebase. This routine
+**    is in the BSP because it is sometimes implemented in hardware and
+**    sometimes taken care of by the RTOS.
+**
+**  Arguments:
+**
+**  Return:
+**  Timebase register value
+*/
+void CFE_PSP_Get_Timebase(uint32 *Tbu, uint32* Tbl)
+{
+   OS_time_t        time;
+
+   OS_GetLocalTime(&time);
+   *Tbu = time.seconds;
+   *Tbl = time.microsecs;
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_Get_Dec()
+**
+**  Purpose:
+**    Provides a common interface to decrementer counter. This routine
+**    is in the PSP because it is sometimes implemented in hardware and
+**    sometimes taken care of by the RTOS.
+**
+**  Arguments:
+**
+**  Return:
+**  Timebase register value
+*/
+
+uint32 CFE_PSP_Get_Dec(void)
+{
+   /* SUB -add function call code*/
+   return(0);
+}
+

--- a/psp/fsw/arm-freertos/src/cfe_psp_watchdog.c
+++ b/psp/fsw/arm-freertos/src/cfe_psp_watchdog.c
@@ -1,0 +1,183 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/************************************************************************************************
+** File:  cfe_psp_watchdog.c
+**
+** Purpose:
+**   This file contains glue routines between the cFE and the OS Board Support Package ( BSP ).
+**   The functions here allow the cFE to interface functions that are board and OS specific
+**   and usually dont fit well in the OS abstraction layer.
+**
+** History:
+**   2009/07/20  A. Cudmore    | Initial version,
+**
+*************************************************************************************************/
+
+/*
+**  Include Files
+*/
+
+
+/*
+** cFE includes
+*/
+#include "common_types.h"
+#include "osapi.h"
+
+/*
+**  System Include Files
+*/
+#include <stdio.h>
+#include <stdlib.h>
+
+/*
+** Types and prototypes for this module
+*/
+#include "cfe_psp.h"
+#include "cfe_psp_config.h"
+
+/*
+** Global data
+*/
+
+/*
+** The watchdog time in milliseconds
+*/
+uint32 CFE_PSP_WatchdogValue = CFE_PSP_WATCHDOG_MAX;
+
+/*  Function:  CFE_PSP_WatchdogInit()
+**
+**  Purpose:
+**    To setup the timer resolution and/or other settings custom to this platform.
+**
+**  Arguments:
+**
+**  Return:
+*/
+void CFE_PSP_WatchdogInit(void)
+{
+
+   /*
+   ** Just set it to a value right now
+   ** The pc-linux desktop platform does not actually implement a watchdog
+   ** timeout ( but could with a signal )
+   */
+   CFE_PSP_WatchdogValue = CFE_PSP_WATCHDOG_MAX;
+
+}
+
+
+/******************************************************************************
+**  Function:  CFE_PSP_WatchdogEnable()
+**
+**  Purpose:
+**    Enable the watchdog timer
+**
+**  Arguments:
+**
+**  Return:
+*/
+void CFE_PSP_WatchdogEnable(void)
+{
+
+}
+
+
+/******************************************************************************
+**  Function:  CFE_PSP_WatchdogDisable()
+**
+**  Purpose:
+**    Disable the watchdog timer
+**
+**  Arguments:
+**
+**  Return:
+*/
+void CFE_PSP_WatchdogDisable(void)
+{
+
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_WatchdogService()
+**
+**  Purpose:
+**    Load the watchdog timer with a count that corresponds to the millisecond
+**    time given in the parameter.
+**
+**  Arguments:
+**    None.
+**
+**  Return:
+**    None
+**
+**  Notes:
+**
+*/
+void CFE_PSP_WatchdogService(void)
+{
+
+
+}
+
+/******************************************************************************
+**  Function:  CFE_PSP_WatchdogGet
+**
+**  Purpose:
+**    Get the current watchdog value. 
+**
+**  Arguments:
+**    none 
+**
+**  Return:
+**    the current watchdog value 
+**
+**  Notes:
+**
+*/
+uint32 CFE_PSP_WatchdogGet(void)
+{
+   return(CFE_PSP_WatchdogValue);
+}
+
+
+/******************************************************************************
+**  Function:  CFE_PSP_WatchdogSet
+**
+**  Purpose:
+**    Get the current watchdog value. 
+**
+**  Arguments:
+**    The new watchdog value 
+**
+**  Return:
+**    nothing 
+**
+**  Notes:
+**
+*/
+void CFE_PSP_WatchdogSet(uint32 WatchdogValue)
+{
+
+    CFE_PSP_WatchdogValue = WatchdogValue;
+
+}
+

--- a/psp/fsw/arm-freertos/src/psp.mak
+++ b/psp/fsw/arm-freertos/src/psp.mak
@@ -1,0 +1,52 @@
+###############################################################################
+# File: psp.mak
+#
+# Purpose:
+#   Platform Support Package routines for the Linux desktop build
+#
+# History:
+#   2005/07/27  A. Cudmore   : Updated for cFE.
+#   2004/04/12  A. Cudmore   : Initial revision for SDO.
+#   2004/05/24  P. Kutt      : Modified for new directory structure; rewrote comments.
+#
+###############################################################################
+
+# Subsystem produced by this makefile.
+TARGET = psp.o
+
+#==============================================================================
+# Object files required to build subsystem.
+#==============================================================================
+OBJS = cfe_psp_start.o \
+cfe_psp_support.o \
+cfe_psp_ssr.o \
+cfe_psp_voltab.o \
+cfe_psp_memtab.o \
+cfe_psp_timer.o \
+cfe_psp_watchdog.o \
+cfe_psp_memory.o \
+cfe_psp_exception.o \
+cfe_psp_ram.o \
+cfe_psp_eeprom.o \
+cfe_psp_port.o \
+cfe_psp_memrange.o \
+cfe_psp_memutils.o
+
+#==============================================================================
+# Source files required to build subsystem; used to generate dependencies.
+SOURCES = cfe_psp_start.c \
+cfe_psp_support.c \
+cfe_psp_ssr.c  \
+cfe_psp_voltab.c \
+cfe_psp_memtab.c \
+cfe_psp_timer.c \
+cfe_psp_watchdog.c \
+cfe_psp_memory.c \
+cfe_psp_exception.c \
+cfe_psp_ram.c \
+cfe_psp_eeprom.c \
+cfe_psp_port.c \
+cfe_psp_memrange.c \
+cfe_psp_memutils.c
+
+

--- a/sample_defs/toolchain-cpu1.cmake
+++ b/sample_defs/toolchain-cpu1.cmake
@@ -19,7 +19,6 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   NEVER)
 
 # These variable settings are specific to cFE/OSAL and determines which 
 # abstraction layers are built when using this toolchain
-SET(CFE_SYSTEM_PSPNAME      "pc-linux")
-SET(OSAL_SYSTEM_BSPNAME     "pc-linux")
-SET(OSAL_SYSTEM_OSTYPE      "posix")
-
+SET(CFE_SYSTEM_PSPNAME      "arm-freertos")
+SET(OSAL_SYSTEM_BSPTYPE     "arm-freertos")
+SET(OSAL_SYSTEM_OSTYPE      "freertos")


### PR DESCRIPTION
**Describe the contribution**
Created new PSP/BSP/OS directories for FreeRTOS port
- Includes the stubbed OSAL which was originally overwriting the posix directory

**Testing performed**
Steps taken to test the contribution:
1. `./run.sh`
1. No compilation errors
1. The system does nothing (stops immediately) as expected

**Expected behavior changes**
Provides a new build directory structure for the BSP/PSP/OS for a FreeRTOS target

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04

**Additional context**
Further configuration will be required in the CMake system to properly compile the system for the desired target. Currently, the system is still built as if the target is a Linux platform (e.g. compiler links to pthread library)

**Contributor Info - All information REQUIRED for consideration of pull request**
 - Stephen Scott, McMaster NEUDOSE
 - John Barberiz, McMaster NEUDOSE
 - Uzair Abbasi, McMaster NEUDOSE
