### PR TITLE
Added Telemetry Subscription Table in CSP App

### DIFF
--- a/apps/csp_app/CMakeLists.txt
+++ b/apps/csp_app/CMakeLists.txt
@@ -3,10 +3,19 @@ project(CSP_APP C)
 
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)
+include_directories(fsw/src)
 
 #required for csp library
 include_directories(${MISSION_SOURCE_DIR}/apps/libcsp/include)
 include_directories(${MISSION_SOURCE_DIR}/apps/libcsp/build/include)
 
+#required for subscription table
+include_directories(${MISSION_SOURCE_DIR}/apps/comms/fsw/platform_inc)
+include_directories(${MISSION_SOURCE_DIR}/apps/eps/fsw/platform_inc)
+include_directories(${MISSION_SOURCE_DIR}/apps/payload/fsw/platform_inc)
+
 # Create the app module
 add_cfe_app(csp_app fsw/src/csp_app.c)
+
+# Add the subscription table
+add_cfe_tables(csp_app fsw/tables/csp_app_subtbl.c)

--- a/apps/csp_app/fsw/platform_inc/csp_app_msgids.h
+++ b/apps/csp_app/fsw/platform_inc/csp_app_msgids.h
@@ -12,9 +12,9 @@
 #ifndef _csp_app_msgids_h_
 #define _csp_app_msgids_h_
 
-#define CSP_APP_CMD_MID            	0x1882
-#define CSP_APP_SEND_HK_MID        	0x1883
-#define CSP_APP_HK_TLM_MID		    0x0883
+#define CSP_APP_CMD_MID            	0x1930
+#define CSP_APP_SEND_HK_MID        	0x1931
+#define CSP_APP_HK_TLM_MID		    0x0930
 
 #endif /* _csp_app_msgids_h_ */
 

--- a/apps/csp_app/fsw/src/csp_app.h
+++ b/apps/csp_app/fsw/src/csp_app.h
@@ -21,15 +21,18 @@
 #include "cfe_evs.h"
 #include "cfe_sb.h"
 #include "cfe_es.h"
+#include "cfe_tbl.h"
 
 #include "csp_app_perfids.h"
 #include "csp_app_msgids.h"
 #include "csp_app_msg.h"
+#include "csp_app_events.h"
 
 /************************************************************************
 ** Depth of the Command Pipe for Application
 *************************************************************************/
-#define CSP_PIPE_DEPTH  32
+#define CSP_CMD_PIPE_DEPTH  32
+#define CSP_TLM_PIPE_DEPTH 	32
 
 /************************************************************************
 ** LibCSP Nodes
@@ -76,27 +79,33 @@ typedef struct
     uint32 RunStatus;
 
     /*
-    ** Operational data (not reported in housekeeping)...
+    ** Command pipe...
     */
-    CFE_SB_PipeId_t     CommandPipe;
-    CFE_SB_MsgPtr_t     MsgPtr;
+    CFE_SB_PipeId_t     CmdPipe;
+    CFE_SB_MsgPtr_t     CmdPtr;
+
+    /*
+    ** Telemetry pipe...
+    */
+    CFE_SB_PipeId_t     TlmPipe;
+    CFE_SB_MsgPtr_t     TlmPtr;
 
     /*
     ** Initialization data (not reported in housekeeping)...
     */
-    char                PipeName[16];
-    uint16              PipeDepth;
+    char                CmdPipeName[16];
+    uint16              CmdPipeDepth;
+    char                TlmPipeName[16];
+    uint16              TlmPipeDepth;
 
     CFE_EVS_BinFilter_t  EventFilters[CSP_EVENT_COUNTS];
 
 } CSP_AppData_t;
 
 /****************************************************************************/
+
 /*
 ** Local function prototypes.
-**
-** Note: Except for the entry point (CSP_AppMain), these
-**       functions are not called from any other source module.
 */
 void  CSP_AppMain(void);
 int32 CSP_AppInit(void);

--- a/apps/csp_app/fsw/src/csp_app_events.h
+++ b/apps/csp_app/fsw/src/csp_app_events.h
@@ -27,7 +27,8 @@
 #define CSP_BUFFERGET_ERR_EID         	11
 #define CSP_SENDTO_ERR_EID            	12
 #define CSP_RECVFROM_ERR_EID          	13
-#define CSP_EVENT_COUNTS              	14
+#define CSP_TBL_ERR_EID 				14
+#define CSP_EVENT_COUNTS              	15
 
 
 #endif /* _csp_app_events_h_ */

--- a/apps/csp_app/fsw/src/csp_app_tbldefs.h
+++ b/apps/csp_app/fsw/src/csp_app_tbldefs.h
@@ -1,0 +1,50 @@
+/*******************************************************************************
+**
+** File: csp_app_tbldefs.h
+**
+** Purpose:
+**   This file is for the CSP table definitions.
+**
+** Author:
+**   Stephen Scott
+**
+*******************************************************************************/
+
+/*
+** Ensure the header is only included once
+*/
+#ifndef _csp_tbldefs_
+#define _csp_tbldefs_
+
+/*
+** CFE includes
+*/
+#include "cfe_sb.h"
+#include "cfe_platform_cfg.h"
+
+/*
+** CSP include necessary for csp_prio_t
+*/
+#include "csp/csp_types.h"
+
+/*******************************************************************************
+**
+** CSP table structure definitions
+**
+*******************************************************************************/
+
+/*
+** CSP definition table entry
+*/
+typedef struct
+{
+	CFE_SB_MsgId_t 	Stream;
+	csp_prio_t 		Priority;
+} CSP_App_Sub_t;
+
+typedef struct
+{
+	CSP_App_Sub_t Subs[CFE_PLATFORM_SB_MAX_MSG_IDS];
+} CSP_App_SubTable_t;
+
+#endif

--- a/apps/csp_app/fsw/src/csp_app_version.h
+++ b/apps/csp_app/fsw/src/csp_app_version.h
@@ -9,8 +9,8 @@
 **   Stephen Scott
 **
 ** Revision History:
-**   12/09/2020: 	1.0.0: 	Creation of base CSP app
-**   14/09/2020: 	1.0.1:	Added subscription table
+**   12/09/2020: 	1.0.0.0: 	Creation of base CSP app
+**   14/09/2020: 	1.0.1.0:	Added subscription table
 **
 *************************************************************************/
 #ifndef _csp_app_version_h_

--- a/apps/csp_app/fsw/src/csp_app_version.h
+++ b/apps/csp_app/fsw/src/csp_app_version.h
@@ -9,18 +9,18 @@
 **   Stephen Scott
 **
 ** Revision History:
-**   12/09/2020: 	1.0.0.0: 	Creation of base CSP app
+**   12/09/2020: 	1.0.0: 	Creation of base CSP app
+**   14/09/2020: 	1.0.1:	Added subscription table
 **
 *************************************************************************/
 #ifndef _csp_app_version_h_
 #define _csp_app_version_h_
 
 
-#define CSP_APP_MAJOR_VERSION              1
-#define CSP_APP_MINOR_VERSION              0
-#define CSP_APP_REVISION                   0
-#define CSP_APP_MISSION_REV                0
-
+#define CSP_APP_MAJOR_VERSION              	1
+#define CSP_APP_MINOR_VERSION              	0
+#define CSP_APP_REVISION                   	1
+#define CSP_APP_MISSION_REV					0
 
 #endif /* _csp_app_version_h_ */
 

--- a/apps/csp_app/fsw/tables/csp_app_subtbl.c
+++ b/apps/csp_app/fsw/tables/csp_app_subtbl.c
@@ -1,0 +1,74 @@
+/*******************************************************************************
+**
+** File: csp_app_subtbl.c
+**
+** Purpose:
+**   This file defines the CSP app subscription table.
+**
+** Author:
+**   Stephen Scott
+**
+*******************************************************************************/
+
+/*
+** Table includes
+*/
+#include "csp_app_tbldefs.h"
+#include "cfe_tbl_filedef.h"
+
+/*******************************************************************************
+**
+** MSGID includes
+**
+*******************************************************************************/
+
+/*
+** CFS App Subscriptions
+*/
+#include "csp_app_msgids.h"
+
+/*
+** Mission Specific App Subscriptions
+*/
+#include "comms_msgids.h"
+#include "eps_msgids.h"
+#include "payload_msgids.h"
+
+/*
+** cFE Core Subscriptions
+*/
+#include "cfe_msgids.h"
+
+/*******************************************************************************
+**
+** Creation of subscription table
+**
+*******************************************************************************/
+
+CSP_App_SubTable_t CSP_App_SubTbl = 
+{
+	{
+		/* CFS App Subscriptions */
+		{CSP_APP_HK_TLM_MID, 			CSP_PRIO_NORM},
+
+		/* Mission Specific App Subscriptions */
+		{COMMS_HK_TLM_MID, 				CSP_PRIO_HIGH},
+		{EPS_HK_TLM_MID, 				CSP_PRIO_HIGH},
+		{PAYLOAD_HK_TLM_MID, 			CSP_PRIO_HIGH},
+
+		/* cFE Core Subscriptions */
+		{CFE_ES_HK_TLM_MID, 			CSP_PRIO_NORM},
+		{CFE_EVS_HK_TLM_MID, 			CSP_PRIO_NORM},
+		{CFE_SB_HK_TLM_MID, 			CSP_PRIO_NORM},
+		{CFE_TBL_HK_TLM_MID, 			CSP_PRIO_NORM},
+		{CFE_TIME_HK_TLM_MID, 			CSP_PRIO_NORM},
+		{CFE_TIME_DIAG_TLM_MID, 		CSP_PRIO_NORM},
+		{CFE_SB_STATS_TLM_MID, 			CSP_PRIO_NORM},
+		{CFE_TBL_REG_TLM_MID, 			CSP_PRIO_NORM},
+		{CFE_EVS_LONG_EVENT_MSG_MID, 	CSP_PRIO_NORM},
+		{CFE_ES_APP_TLM_MID, 			CSP_PRIO_NORM},
+		{CFE_ES_MEMSTATS_TLM_MID, 		CSP_PRIO_NORM}
+	}
+};
+
+CFE_TBL_FILEDEF(CSP_App_SubTbl, CSP_APP.CSP_App_SubTbl, CSP App Sub Tbl, csp_app_subtbl.tbl)


### PR DESCRIPTION
**Describe the contribution**
Added a telemetry subscription table that specifies msgid and CSP priority for telemetry packets.
- Changed msgids in platform_inc to make them unique

**Testing performed**
1. Added system log message to ensure all msgids were being subscribed to (this message is now removed)
1. `./run.sh`
1. Compiled/executed with no errors
1. Observed the system log message to ensure all the msgids were subscribed to the telemetry pipe

**Expected behavior changes**
- CSP App now has two pipes on the SB
    - Command Pipe
    - Telemetry Pipe
- Subscription table is loaded in the CSP App initialization state

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04

**Additional context**
- Telemetry pipe will feed packets to the TO child task, which will send the packets to the CAN Bus
- Next step is creating the TO child task

**Contributor Info - All information REQUIRED for consideration of pull request**
- Stephen Scott, McMaster NEUDOSE
